### PR TITLE
Change NLB resources default values

### DIFF
--- a/exoscale/loadbalancer.go
+++ b/exoscale/loadbalancer.go
@@ -235,11 +235,11 @@ func (l *loadBalancer) fetchLoadBalancerService(lb *egoscale.NetworkLoadBalancer
 	if err != nil {
 		return nil, err
 	}
-	defaultServicePort := fmt.Sprintf("%s-%d", service.UID, ports[0])
+	defaultServiceName := fmt.Sprintf("%s-%d", service.UID, ports[0])
 
 	for _, svc := range lb.Services {
 		if svc.ID == getAnnotation(service, annotationLoadBalancerServiceID, "") ||
-			svc.Name == getAnnotation(service, annotationLoadBalancerServiceName, defaultServicePort) {
+			svc.Name == getAnnotation(service, annotationLoadBalancerServiceName, defaultServiceName) {
 			return svc, nil
 		}
 	}


### PR DESCRIPTION
This commit changes the default values used for NLB resources names and services names, and enforces sanity checks for ports and protocols specified in the k8s `Service` specs.

Note: the relevant parts of the documentation will be updated in a different PR which completely overhauls the project documentation.