### PR TITLE
Allow to specify a default load-balancer zone

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,7 @@ provide to the CCM in your shell:
 ```Shell
 export EXOSCALE_API_KEY="EXOxxxxxxxxxxxxxxxxxxxxxxxx"
 export EXOSCALE_API_SECRET="xxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export EXOSCALE_DEFAULT_ZONE="ch-gva-2"
 ```
 
 Next, run the following command from the same shell:

--- a/docs/service-loadbalancer.md
+++ b/docs/service-loadbalancer.md
@@ -90,6 +90,8 @@ instance.
 > Note: a CCM-managed Network Load Balancer must be located in the same zone as
 > the Kubernetes Nodes it must forward network traffic to.
 
+If this annotation is not present, the default value will be taken from the `EXOSCALE_DEFAULT_ZONE` environment variable.
+
 
 #### `service.beta.kubernetes.io/exoscale-loadbalancer-id`
 

--- a/exoscale/exoscale.go
+++ b/exoscale/exoscale.go
@@ -3,6 +3,7 @@ package exoscale
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/exoscale/egoscale"
 	"k8s.io/client-go/kubernetes"
@@ -26,6 +27,7 @@ type cloudProvider struct {
 	zones        cloudprovider.Zones
 	loadBalancer cloudprovider.LoadBalancer
 	kclient      kubernetes.Interface
+	defaultZone  string
 }
 
 func init() {
@@ -47,6 +49,7 @@ func newExoscaleCloud() (cloudprovider.Interface, error) {
 	provider.instances = newInstances(provider)
 	provider.loadBalancer = newLoadBalancer(provider)
 	provider.zones = newZones(provider)
+	provider.defaultZone = os.Getenv("EXOSCALE_DEFAULT_ZONE")
 
 	return provider, nil
 

--- a/exoscale/loadbalancer.go
+++ b/exoscale/loadbalancer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -393,6 +394,9 @@ func getAnnotation(service *v1.Service, annotation, defaultValue string) string 
 func getLoadBalancerZone(service *v1.Service) (string, error) {
 	zone, ok := service.Annotations[annotationLoadBalancerZone]
 	if !ok {
+		if defaultZone := os.Getenv("EXOSCALE_DEFAULT_LOADBALANCER_ZONE"); defaultZone != "" {
+			return defaultZone, nil
+		}
 		return "", errors.New("annotation " + annotationLoadBalancerZone + " is missing")
 	}
 


### PR DESCRIPTION
Allow to specify a default load-balancer zone
    
This avoids having to specify the mandatory `service.beta.kubernetes.io/exoscale-loadbalancer-zone` for each service.

