### PR TITLE
Fix provider ID formatting logic

### DIFF
--- a/exoscale/common.go
+++ b/exoscale/common.go
@@ -59,13 +59,7 @@ func formatProviderID(providerID string) (string, error) {
 		return "", errors.New("provider ID cannot be empty")
 	}
 
-	const prefix = "exoscale://"
-
-	if !strings.HasPrefix(providerID, prefix) {
-		return "", fmt.Errorf("provider ID %q is missing prefix %q", providerID, prefix)
-	}
-
-	return strings.TrimPrefix(providerID, prefix), nil
+	return strings.TrimPrefix(providerID, providerPrefix), nil
 }
 
 func queryInstanceMetadata(key string) (string, error) {

--- a/exoscale/exoscale.go
+++ b/exoscale/exoscale.go
@@ -18,7 +18,8 @@ var (
 )
 
 const (
-	providerName string = "exoscale"
+	providerName   = "exoscale"
+	providerPrefix = "exoscale://"
 )
 
 type cloudProvider struct {


### PR DESCRIPTION
This change fixes the `formatProviderID()` function to allow for
unprefixed Instance IDs (i.e. without `exoscale://`).