### PR TITLE
Fix integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
       run: git submodule update --init --recursive go.mk
     - uses: azure/setup-kubectl@v1
       with:
-        version: v1.18.2
+        version: v1.18.5
       id: install
     - name: Install Exoscale CLI
       run: |
-        wget -qO cli.deb https://github.com/exoscale/cli/releases/download/v1.15.0/exoscale-cli_1.15.0_linux_amd64.deb
+        wget -qO cli.deb https://github.com/exoscale/cli/releases/download/v1.17.0/exoscale-cli_1.17.0_linux_amd64.deb
         sudo dpkg -i cli.deb
 
         echo "::set-env name=EXOSCALE_API_KEY::${{ secrets.EXOSCALE_API_KEY }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: docker-build
     steps:
     - uses: actions/checkout@v2

--- a/integtest/run.bash
+++ b/integtest/run.bash
@@ -23,18 +23,19 @@ export EXOSCALE_LB_SERVICE_NAME1
 EXOSCALE_LB_SERVICE_NAME2=k8s-ccm-lb-service-$(uuidgen | tr '[:upper:]' '[:lower:]')
 export EXOSCALE_LB_SERVICE_NAME2
 
+trap cleanup EXIT
+
 cleanup() {
     rm -rf "${INTEGTEST_TMP_DIR}"
     exo --quiet vm delete --force "$EXOSCALE_MASTER_NAME"
-    exo --quiet nlb delete --force "$EXOSCALE_LB_NAME" -z de-fra-1 &>/dev/null || true
+    exo --quiet nlb delete --force "$EXOSCALE_LB_NAME" -z de-fra-1 || true
     until_success "exo --quiet instancepool delete --force \"${EXOSCALE_INSTANCEPOOL_NAME}\" -z de-fra-1" || true
     until_success "exo --quiet sshkey delete --force \"$EXOSCALE_SSHKEY_NAME\""
 }
-trap cleanup EXIT
 
 until_success() {
     declare command="$1"
-    timeout 10m bash -c "until $command &>/dev/null; do sleep 5; done" --preserve-status
+    timeout 10m bash -c "until $command; do sleep 5; done" --preserve-status
 }
 
 remote_run() {

--- a/integtest/run.bash
+++ b/integtest/run.bash
@@ -28,14 +28,14 @@ trap cleanup EXIT
 cleanup() {
     rm -rf "${INTEGTEST_TMP_DIR}"
     exo --quiet vm delete --force "$EXOSCALE_MASTER_NAME"
-    exo --quiet nlb delete --force "$EXOSCALE_LB_NAME" -z de-fra-1 || true
+    exo --quiet nlb delete --force "$EXOSCALE_LB_NAME" -z de-fra-1 2>/dev/null || true
     until_success "exo --quiet instancepool delete --force \"${EXOSCALE_INSTANCEPOOL_NAME}\" -z de-fra-1" || true
     until_success "exo --quiet sshkey delete --force \"$EXOSCALE_SSHKEY_NAME\""
 }
 
 until_success() {
     declare command="$1"
-    timeout 10m bash -c "until $command; do sleep 5; done" --preserve-status
+    timeout 10m bash -c "until $command 2>/dev/null; do sleep 5; done" --preserve-status
 }
 
 remote_run() {

--- a/integtest/run.bash
+++ b/integtest/run.bash
@@ -35,7 +35,7 @@ cleanup() {
 
 until_success() {
     declare command="$1"
-    timeout 10m bash -c "until $command 2>/dev/null; do sleep 5; done" --preserve-status
+    timeout 10m bash -c "until $command > /dev/null 2>&1; do sleep 5; done" --preserve-status
 }
 
 remote_run() {

--- a/integtest/run.bash
+++ b/integtest/run.bash
@@ -34,7 +34,7 @@ trap cleanup EXIT
 
 until_success() {
     declare command="$1"
-    timeout 2m bash -c "until $command &>/dev/null; do sleep 5; done" --preserve-status
+    timeout 10m bash -c "until $command &>/dev/null; do sleep 5; done" --preserve-status
 }
 
 remote_run() {
@@ -90,7 +90,7 @@ deploy_exoscale_ccm() {
     "${INCLUDE_PATH}/docs/scripts/generate-secret.sh"
     kubectl apply --filename "${INTEGTEST_DIR}/manifests/deployment.yml"
 
-    kubectl wait --namespace kube-system deployment.apps/exoscale-cloud-controller-manager --for=condition=available --timeout=600s
+    kubectl wait --namespace kube-system deployment.apps/exoscale-cloud-controller-manager --for=condition=Available --timeout=600s
 }
 
 instancepool_join_k8s() {

--- a/integtest/run.bash
+++ b/integtest/run.bash
@@ -34,7 +34,7 @@ trap cleanup EXIT
 
 until_success() {
     declare command="$1"
-    timeout 2m bash -c "until $command &>/dev/null; do sleep 5; done"
+    timeout 2m bash -c "until $command &>/dev/null; do sleep 5; done" --preserve-status
 }
 
 remote_run() {
@@ -81,7 +81,7 @@ initialize_k8s_master() {
     kubectl create --filename https://docs.projectcalico.org/manifests/tigera-operator.yaml
     kubectl create --filename https://docs.projectcalico.org/manifests/custom-resources.yaml
 
-    kubectl wait "node/${EXOSCALE_MASTER_NAME}" --for=condition=Ready --timeout=180s
+    kubectl wait "node/${EXOSCALE_MASTER_NAME}" --for=condition=Ready --timeout=600s
 }
 
 deploy_exoscale_ccm() {
@@ -90,7 +90,7 @@ deploy_exoscale_ccm() {
     "${INCLUDE_PATH}/docs/scripts/generate-secret.sh"
     kubectl apply --filename "${INTEGTEST_DIR}/manifests/deployment.yml"
 
-    kubectl wait --namespace kube-system deployment.apps/exoscale-cloud-controller-manager --for=condition=available --timeout=180s
+    kubectl wait --namespace kube-system deployment.apps/exoscale-cloud-controller-manager --for=condition=available --timeout=600s
 }
 
 instancepool_join_k8s() {
@@ -115,13 +115,13 @@ instancepool_join_k8s() {
     export EXOSCALE_NODE_NAME
 
     until_success "kubectl get node \"${EXOSCALE_NODE_NAME}\""
-    kubectl wait "node/${EXOSCALE_NODE_NAME}" --for=condition=Ready --timeout=180s
+    kubectl wait "node/${EXOSCALE_NODE_NAME}" --for=condition=Ready --timeout=600s
 }
 
 deploy_nginx_app() {
     kubectl apply --filename "${INTEGTEST_DIR}/manifests/app.yml"
 
-    kubectl wait deployment.apps/nginx --for=condition=Available --timeout=180s
+    kubectl wait deployment.apps/nginx --for=condition=Available --timeout=600s
 }
 
 create_external_loadbalancer() {

--- a/integtest/run.bash
+++ b/integtest/run.bash
@@ -23,6 +23,9 @@ export EXOSCALE_LB_SERVICE_NAME1
 EXOSCALE_LB_SERVICE_NAME2=k8s-ccm-lb-service-$(uuidgen | tr '[:upper:]' '[:lower:]')
 export EXOSCALE_LB_SERVICE_NAME2
 
+KUBE_TIMEOUT=600s
+export KUBE_TIMEOUT
+
 trap cleanup EXIT
 
 cleanup() {
@@ -82,7 +85,7 @@ initialize_k8s_master() {
     kubectl create --filename https://docs.projectcalico.org/manifests/tigera-operator.yaml
     kubectl create --filename https://docs.projectcalico.org/manifests/custom-resources.yaml
 
-    kubectl wait "node/${EXOSCALE_MASTER_NAME}" --for=condition=Ready --timeout=600s
+    kubectl wait "node/${EXOSCALE_MASTER_NAME}" --for=condition=Ready --timeout="${KUBE_TIMEOUT}"
 }
 
 deploy_exoscale_ccm() {
@@ -91,7 +94,7 @@ deploy_exoscale_ccm() {
     "${INCLUDE_PATH}/docs/scripts/generate-secret.sh"
     kubectl apply --filename "${INTEGTEST_DIR}/manifests/deployment.yml"
 
-    kubectl wait --namespace kube-system deployment.apps/exoscale-cloud-controller-manager --for=condition=Available --timeout=600s
+    kubectl wait --namespace kube-system deployment.apps/exoscale-cloud-controller-manager --for=condition=Available --timeout="${KUBE_TIMEOUT}"
 }
 
 instancepool_join_k8s() {
@@ -116,13 +119,13 @@ instancepool_join_k8s() {
     export EXOSCALE_NODE_NAME
 
     until_success "kubectl get node \"${EXOSCALE_NODE_NAME}\""
-    kubectl wait "node/${EXOSCALE_NODE_NAME}" --for=condition=Ready --timeout=600s
+    kubectl wait "node/${EXOSCALE_NODE_NAME}" --for=condition=Ready --timeout="${KUBE_TIMEOUT}"
 }
 
 deploy_nginx_app() {
     kubectl apply --filename "${INTEGTEST_DIR}/manifests/app.yml"
 
-    kubectl wait deployment.apps/nginx --for=condition=Available --timeout=600s
+    kubectl wait deployment.apps/nginx --for=condition=Available --timeout="${KUBE_TIMEOUT}"
 }
 
 create_external_loadbalancer() {

--- a/integtest/test-nlb.bash
+++ b/integtest/test-nlb.bash
@@ -28,7 +28,7 @@ EXOSCALE_LB_IP=$(kubectl get service/nginx-service -o=jsonpath="{.status.loadBal
 
 curl -i --retry 10 --silent --output /dev/null "http://$EXOSCALE_LB_IP"
 
-kubectl delete service/nginx-service --timeout=600s
+kubectl delete service/nginx-service --timeout="${KUBE_TIMEOUT}"
 
 nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Strategy" "source-hash"
 nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Protocol" "tcp"
@@ -42,4 +42,4 @@ nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Healthcheck.Retries" "2"
 
 curl -i --retry 10 --silent --output /dev/null "http://$EXOSCALE_LB_IP:8080"
 
-kubectl delete service/nginx-service-2 --timeout=600s
+kubectl delete service/nginx-service-2 --timeout="${KUBE_TIMEOUT}"

--- a/integtest/test-nlb.bash
+++ b/integtest/test-nlb.bash
@@ -28,7 +28,7 @@ EXOSCALE_LB_IP=$(kubectl get service/nginx-service -o=jsonpath="{.status.loadBal
 
 curl -i --silent --output /dev/null "http://$EXOSCALE_LB_IP"
 
-kubectl delete service/nginx-service --timeout=180s
+kubectl delete service/nginx-service --timeout=600s
 
 nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Strategy" "source-hash"
 nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Protocol" "tcp"
@@ -42,4 +42,4 @@ nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Healthcheck.Retries" "2"
 
 curl -i --silent --output /dev/null "http://$EXOSCALE_LB_IP:8080"
 
-kubectl delete service/nginx-service-2 --timeout=180s
+kubectl delete service/nginx-service-2 --timeout=600s

--- a/integtest/test-nlb.bash
+++ b/integtest/test-nlb.bash
@@ -26,7 +26,7 @@ nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME1" ".Healthcheck.Retries" "1"
 
 EXOSCALE_LB_IP=$(kubectl get service/nginx-service -o=jsonpath="{.status.loadBalancer.ingress[*].ip}")
 
-curl -i --silent --output /dev/null "http://$EXOSCALE_LB_IP"
+curl -i --retry 10 --silent --output /dev/null "http://$EXOSCALE_LB_IP"
 
 kubectl delete service/nginx-service --timeout=600s
 
@@ -40,6 +40,6 @@ nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Healthcheck.Interval" "1
 nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Healthcheck.Timeout" "6s"
 nlb_service_assert_equal "$EXOSCALE_LB_SERVICE_NAME2" ".Healthcheck.Retries" "2"
 
-curl -i --silent --output /dev/null "http://$EXOSCALE_LB_IP:8080"
+curl -i --retry 10 --silent --output /dev/null "http://$EXOSCALE_LB_IP:8080"
 
 kubectl delete service/nginx-service-2 --timeout=600s


### PR DESCRIPTION
this PR increases the time before timeout

when for example we create an nlb service it is linked to an instance pool and in some cases when deleting the pool instance, the nlb service did not have time to delete itself properly, so it returns errors. That's why we have a `until_success()` function that allows us to restart the command for a given time

and in some cases there wasn't enough time