### PR TITLE
Instances.InstanceID: return InstanceNotFound if the instance doesn't exist

### DIFF
--- a/exoscale/instances.go
+++ b/exoscale/instances.go
@@ -52,6 +52,10 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	instance, err := i.p.computeInstanceByName(ctx, nodeName)
 	if err != nil {
+		if csError, ok := err.(*egoscale.ErrorResponse); ok && csError.ErrorCode == egoscale.ParamError {
+			return "", cloudprovider.InstanceNotFound
+		}
+
 		return "", err
 	}
 


### PR DESCRIPTION
As described [in the interface](https://github.com/kubernetes/cloud-provider/blob/release-1.17/cloud.go#L170:L173) the `InstanceID` method should return `"", cloudprovider.InstanceNotFound` if the instance does not exist.

I is implemented [the same way as for `InstanceExistsByProviderID`](b/262566639ce5a12d9db8691fa8857f0a3b7b5d72/exoscale/instances.go#L100)

This fixes an error while cleaning up nodes that have been deleted before being initialized:

```
E1207 13:42:09.098553       1 node_lifecycle_controller.go:149] error checking if node XXXXXXXXXXXXXXXXXXXXXXXXXX exists: API error ParamError 431 (ServerAPIException 9999): not found, query: apikey=EXOXXXXXXXXXXXXXXXXXXXXXXXX, command=listVirtualMachines, name=XXXXXXXXXXXXXXXXXXXXXXXXXX
```