### PR TITLE
Get the instance id from nodeObject.status.nodeInfo.systemUUID

### DIFF
--- a/exoscale/common.go
+++ b/exoscale/common.go
@@ -10,19 +10,9 @@ import (
 
 	"github.com/exoscale/egoscale"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const metadataEndpoint = "http://metadata.exoscale.com/1.0/meta-data/"
-
-func (c *cloudProvider) computeInstanceByName(ctx context.Context, name types.NodeName) (*egoscale.VirtualMachine, error) {
-	r, err := c.client.GetWithContext(ctx, egoscale.VirtualMachine{Name: string(name)})
-	if err != nil {
-		return nil, err
-	}
-
-	return r.(*egoscale.VirtualMachine), nil
-}
 
 func (c *cloudProvider) computeInstanceByProviderID(ctx context.Context, providerID string) (*egoscale.VirtualMachine, error) {
 	id, err := formatProviderID(providerID)


### PR DESCRIPTION
Currently the CCM fetches the ID of an instance by calling the Exoscale API and filtering by instance name.
It assumes the name of the Exoscale instance is the same as the name of the Kubernetes node.

By default the kubelet registers the node using the instance hostname, this can be overridden.
The hostname could also have been modified via cloud-init or another configuration tool making it different from the instance name.

After looking at closer at the Node object, it appears that the ID of the instance is already here.
```
apiVersion: v1
kind: Node
status:
  nodeInfo:
    systemUUID: 3f9944b0-2026-40aa-ac2e-ea277a64b101
```

After digging further into the code it turns out this id is taken from [/sys/class/dmi/id/product_uuid](https://github.com/google/cadvisor/blob/8450c56c21bc5406e2df79a2162806b9a23ebd34/utils/sysfs/sysfs.go#L324) and reported back to the apiserver by the kubelet
```
$ sudo cat /sys/class/dmi/id/product_uuid
3f9944b0-2026-40aa-ac2e-ea277a64b101
```