### PR TITLE
Improve Load Balancer Instance Pool detection logic

### DIFF
--- a/exoscale/loadbalancer.go
+++ b/exoscale/loadbalancer.go
@@ -81,34 +81,37 @@ func (l *loadBalancer) EnsureLoadBalancer(ctx context.Context, _ string, service
 	// Inferring the Instance Pool ID from the cluster Nodes that run the Service in case no Instance Pool ID
 	// has been specified in the annotations.
 	//
-	// IMPORTANT: this use case is not compatible with Services referencing pods using Node Selectors
+	// IMPORTANT: this use case is not compatible with Services referencing Pods using Node Selectors
 	// (see https://github.com/kubernetes/kubernetes/issues/45234 for an explanation of the problem).
 	// The list of Nodes passed as argument to this method contains *ALL* the Nodes in the cluster, not only the
-	// ones that actually host the containers targeted by the Service.
+	// ones that actually host the Pods targeted by the Service.
 	if getAnnotation(service, annotationLoadBalancerServiceInstancePoolID, "") == "" {
 		debugf("no NLB service Instance Pool ID specified in Service annotations, inferring from cluster Nodes")
 
 		instancePoolID := ""
-		instancePools := make(map[string]struct{})
 		for _, node := range nodes {
 			instance, err := l.fetchComputeInstanceFromNode(ctx, node)
 			if err != nil {
 				return nil, err
 			}
 
+			// Standalone Node, leaving it alone.
 			if instance.Manager != "instancepool" {
-				return nil, fmt.Errorf("cluster Node %q is not an Instance Pool member", node.Name)
+				continue
 			}
 
-			instancePools[instance.ManagerID.String()] = struct{}{}
+			if instancePoolID != "" && instance.ManagerID.String() != instancePoolID {
+				return nil, errors.New(
+					"multiple Instance Pools detected across cluster Nodes, " +
+						"an Instance Pool ID must be specified in Service manifest annotations",
+				)
+			}
+
 			instancePoolID = instance.ManagerID.String()
 		}
 
-		if len(instancePools) > 1 {
-			return nil, errors.New(
-				"multiple Instance Pools detected across cluster Nodes, " +
-					"an Instance Pool ID must be specified in Service manifest annotations",
-			)
+		if instancePoolID == "" {
+			return nil, errors.New("couldn't infer any Instance Pool from cluster Nodes")
 		}
 
 		debugf("inferred NLB service Instance Pool ID from cluster Nodes: %s", instancePoolID)


### PR DESCRIPTION
This change improves the Load Balancer controller logic when dealing
with clusters spanning multiple Nodepools/Instance Pools: if no Instance
Pool ID is specified in a Service annotations, the CCM will return an
explicit error if it finds multiple Instance Pools across the cluster
instead of assuming all Nodes are member of the same Instance Pool.