### PR TITLE
Add suport for healthCheckNodePort with NLB services

### DIFF
--- a/integtest/manifests/ingress-nginx.yml.tpl
+++ b/integtest/manifests/ingress-nginx.yml.tpl
@@ -281,8 +281,6 @@ metadata:
     app.kubernetes.io/component: controller
   name: ingress-nginx-controller
   namespace: ingress-nginx
-  annotations:
-    service.beta.kubernetes.io/exoscale-loadbalancer-zone: %%EXOSCALE_ZONE%%
 spec:
   type: LoadBalancer
   ports:

--- a/integtest/test-csr-validation.bash
+++ b/integtest/test-csr-validation.bash
@@ -18,7 +18,4 @@ echo "- Checking that the Node CSR got approved"
 
 _until_success "test \$(kubectl get csr --no-headers | awk '\$4 ~ /^system:node:pool-/ && \$5 ~ /Approved/' | wc -l) -eq 2"
 
-CCM_POD="$(kubectl get pods -n kube-system -l app=exoscale-cloud-controller-manager -o name)"
-test $(kubectl -n kube-system logs $CCM_POD | grep -c "sks-agent: CSR .* approved") -eq 2
-
 echo "<<< PASS"


### PR DESCRIPTION
This change adds support for K8s Services using
`externalTrafficPolicy:Local` and `healthCheckNodePort`, which allows
for configurations preserving the clients source IP address as described
in [this article][0].

[0]: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer