### PR TITLE
Replace deprecated resources from integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.17'
+        go-version: '~1.17'
     - name: Init go.mk submodule
       run: git submodule update --init --recursive go.mk
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42
+        version: v1.45
     - name: Run tests
       run: make test-verbose
 
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.17'
+        go-version: '~1.17'
     - name: Init go.mk submodule
       run: git submodule update --init --recursive go.mk
     - name: Build
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '^1.17'
+        go-version: '~1.17'
     - name: Init go.mk submodule
       run: git submodule update --init --recursive go.mk
     - name: Build Docker image


### PR DESCRIPTION
- Remove exoscale_security_group_rules in favor of exoscale_security_group_rule
- Replace local_file by local_sensitive_file
- Also fix the wrong go version used by the CI, keeping 1.17 instead of 1.18.