### PR TITLE
Add cloud-config (file) and instances override support

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,12 +52,12 @@ The following environment variables are available to configure Exoscale CCM:
 * `EXOSCALE_ZONE` [**required**]: the Exoscale zone which the cluster/CCM
   runs in; e.g. `ch-gva-2`
 
-* `EXOSCALE_API_KEY` / `EXOSCALE_API_SECRET` [**required**]: Exoscale API
+* `EXOSCALE_API_KEY` / `EXOSCALE_API_SECRET` [**required**]: actual Exoscale API
   credentials
 
 * `EXOSCALE_API_CREDENTIALS_FILE` [**optional**]: Exoscale API
   credentials (JSON) file; see further below for its format.
-  _Ignored** if actual credentials are provided_
+  _Ignored if actual credentials are provided_
 
 Which may be passed to the CCM container thanks to Kubernetes [Secrets][k8s-secrets]
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,8 +37,31 @@ Upon successful build, the resulting local image is
 > resources in the `kube-system` namespace of the target Kubernetes cluster.
 
 In order to interact with the Exoscale API, the Exoscale CCM must be configured
-with API credentials. This can be achieved using Kubernetes
-[*Secrets*][k8s-secrets], by exposing those as container environment variables.
+with API credentials. This can be achieved:
+* using Kubernetes [*Secrets*][k8s-secrets], by exposing those as container
+  environment variables
+* as a separate (JSON) credentials file, which will be watched for changes
+  (allowing API credentials to be dymically set/refreshed)
+* using the (YAML) configuration file
+  (`--cloud-config`; see below for further details)
+
+### Using Kubernetes Secrets
+
+The following environment variables are available to configure Exoscale CCM:
+
+* `EXOSCALE_ZONE` [**required**]: the Exoscale zone which the cluster/CCM
+  runs in; e.g. `ch-gva-2`
+
+* `EXOSCALE_API_KEY` / `EXOSCALE_API_SECRET` [**required**]: Exoscale API
+  credentials
+
+* `EXOSCALE_API_CREDENTIALS_FILE` [**optional**]: Exoscale API
+  credentials (JSON) file; see further below for its format.
+  _Ignored** if actual credentials are provided_
+
+Which may be passed to the CCM container thanks to Kubernetes [Secrets][k8s-secrets]
+
+#### Helper script
 
 We provide a convenience script that generates and applies a k8s manifest
 declaring Exoscale API credentials as a k8s *Secret* in your cluster from your
@@ -69,6 +92,82 @@ successfully by running the following command:
 kubectl get secret --namespace kube-system exoscale-credentials
 ```
 
+### Using the Cloud Configuration File (--cloud-config)
+
+Exoscale CCM may be configured using the so-called (optional) Cloud Configuration File,
+specified by the `--cloud-config <path>` option when launching the CCM container.
+
+This file must be YAML-formatted and provides the following parameters (which may used _instead_
+of the environment variables mentioned above):
+
+``` yaml
+# Global (API) configuration
+global:
+  zone: "<EXOSCALE_ZONE>"
+  apiKey: "<EXOSCALE_API_KEY>"
+  apiSecret: "<EXOSCALE_API_SECRET>"
+  apiCredentialsFile: "<EXOSCALE_API_CREDENTIALS_FILE>"
+```
+
+#### Overrides
+
+The configuration files also allows to statically override (Exoscale API-derived) Instances
+metadata or support external Nodes:
+
+``` yaml
+instances:
+  overrides:
+  - name: "some-node"
+    addresses:
+    - type: "InternalIP"
+      address: "192.0.2.123"
+    region: "some-alternate-region"
+  - name: "/^some-external-/"
+    external: true
+    type: "some-external-type"
+    region: "some-external-region"
+```
+
+The following parameters are available to configure overrides:
+
+* `name` [string, **required**]: an individual node name or a `/.../`-specified regular expression
+  to match node(s) name(s)
+
+* `external` [boolean, optional]: whether the node/instance is managed
+  by the Exoscale API (`false`; the default) or not (`true`)
+
+* `externalID` [string, optional]: the external node/instance ID; ignored if `external=false`.
+  Defaults to `external-<sha256sum(name)>` if unspecified.
+
+* `type` [string, optional]: the node/instance Type (overrides the API-provided one).
+  Defaults to `external` if unspecified and `external=true`.
+
+* `addresses` [list, optional]: the node/instance addresses (overrides the API-provided one)
+
+  - `type` [string]: the address (Kubernetes `v1.NodeAddressType`) type: _Hostname_, _ExternalIP_, _InternalIP_, _ExternalDNS_, _InternalDNS_
+
+  - `address` [string]: the actual IP address or host name
+
+  If unspecified (empty) and `external=true`, Kubernetes will keep the Kubelet-registered
+  _InternalIP_ address "as is".
+
+* `region`: the node/instance Region (does _not_ override the API-provided one).
+  Defaults to `external` if unspecified and `external=true`.
+
+### Using API Credentials File
+
+Exoscale API credentials may be dynamically set/refreshed using a
+JSON-formatted file:
+
+``` json
+{
+    "api_key": "EXO<key>",
+    "api_secret": "<secret>"
+}
+```
+
+Which path is specified using the `EXOSCALE_API_CREDENTIALS_FILE` environment variable
+or `apiCredentialsFile` Cloud Configuration File parameter.
 
 ### Deploying the Exoscale Cloud Controller Manager
 

--- a/exoscale/client_test.go
+++ b/exoscale/client_test.go
@@ -9,27 +9,12 @@ import (
 	"time"
 )
 
-var (
-	testAPIKey    = new(exoscaleCCMTestSuite).randomString(10)
-	testAPISecret = new(exoscaleCCMTestSuite).randomString(10)
-)
-
-func (ts *exoscaleCCMTestSuite) Test_newRefreshableExoscaleClient_no_env() {
-	os.Unsetenv("EXOSCALE_API_KEY")
-	os.Unsetenv("EXOSCALE_API_SECRET")
-
-	_, err := newRefreshableExoscaleClient(context.Background())
+func (ts *exoscaleCCMTestSuite) Test_newRefreshableExoscaleClient_no_config() {
+	_, err := newRefreshableExoscaleClient(context.Background(), &testConfig_empty.Global)
 	ts.Require().Error(err)
 }
 
-func (ts *exoscaleCCMTestSuite) Test_newRefreshableExoscaleClient_env_credentials() {
-	os.Setenv("EXOSCALE_API_KEY", testAPIKey)
-	os.Setenv("EXOSCALE_API_SECRET", testAPISecret)
-	defer func() {
-		os.Unsetenv("EXOSCALE_API_KEY")
-		os.Unsetenv("EXOSCALE_API_SECRET")
-	}()
-
+func (ts *exoscaleCCMTestSuite) Test_newRefreshableExoscaleClient_credentials() {
 	expected := &refreshableExoscaleClient{
 		RWMutex: &sync.RWMutex{},
 		apiCredentials: exoscaleAPICredentials{
@@ -39,7 +24,7 @@ func (ts *exoscaleCCMTestSuite) Test_newRefreshableExoscaleClient_env_credential
 		apiEnvironment: defaultComputeEnvironment,
 	}
 
-	actual, err := newRefreshableExoscaleClient(context.Background())
+	actual, err := newRefreshableExoscaleClient(context.Background(), &testConfig_typical.Global)
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected.apiCredentials, actual.apiCredentials)
 	ts.Require().NotNil(actual.exo)

--- a/exoscale/exoscale_config.go
+++ b/exoscale/exoscale_config.go
@@ -1,0 +1,58 @@
+package exoscale
+
+import (
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type cloudConfig struct {
+	Global       globalConfig
+	Instances    instancesConfig
+	LoadBalancer loadBalancerConfig `yaml:"loadBalancer"`
+}
+
+type globalConfig struct {
+	Zone               string
+	ApiKey             string `yaml:"apiKey"`
+	ApiSecret          string `yaml:"apiSecret"`
+	ApiCredentialsFile string `yaml:"apiCredentialsFile"`
+	ApiEnvironment     string `yaml:"apiEnvironment"`
+}
+
+func readExoscaleConfig(config io.Reader) (cloudConfig, error) {
+	cfg := cloudConfig{}
+
+	// Unmarshall configuration file (YAML)
+	if config != nil {
+		err := yaml.NewDecoder(config).Decode(&cfg)
+		if err != nil {
+			return cloudConfig{}, err
+		}
+	}
+
+	// From environment
+	if value, exists := os.LookupEnv("EXOSCALE_ZONE"); exists {
+		cfg.Global.Zone = value
+	}
+	if value, exists := os.LookupEnv("EXOSCALE_API_KEY"); exists {
+		cfg.Global.ApiKey = value
+	}
+	if value, exists := os.LookupEnv("EXOSCALE_API_SECRET"); exists {
+		cfg.Global.ApiSecret = value
+	}
+	if value, exists := os.LookupEnv("EXOSCALE_API_CREDENTIALS_FILE"); exists {
+		cfg.Global.ApiCredentialsFile = value
+	}
+	if value, exists := os.LookupEnv("EXOSCALE_API_ENVIRONMENT"); exists {
+		cfg.Global.ApiEnvironment = value
+	}
+
+	// Defaults
+	if cfg.Global.ApiEnvironment == "" {
+		cfg.Global.ApiEnvironment = defaultComputeEnvironment
+	}
+
+	return cfg, nil
+}

--- a/exoscale/exoscale_config_test.go
+++ b/exoscale/exoscale_config_test.go
@@ -1,0 +1,144 @@
+package exoscale
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+var (
+	// Global
+	testZone               = "ch-gva-2"
+	testAPIKey             = new(exoscaleCCMTestSuite).randomString(10)
+	testAPISecret          = new(exoscaleCCMTestSuite).randomString(10)
+	testAPICredentialsFile = new(exoscaleCCMTestSuite).randomString(10)
+	testAPIEnvironment     = "test"
+
+	// Config
+	testConfig_empty   = cloudConfig{}
+	testConfig_typical = cloudConfig{
+		Global: globalConfig{
+			Zone:      testZone,
+			ApiKey:    testAPIKey,
+			ApiSecret: testAPISecret,
+		},
+		Instances:    instancesConfig{
+			Overrides: []instancesOverrideConfig{{
+				Name: testInstanceOverrideRegexpName,
+				External: true,
+				Type: testInstanceOverrideExternalType,
+				Addresses: []instancesOverrideAddressConfig{
+					{Type: "InternalIP", Address: testInstanceOverrideAddress_internal},
+					{Type: "ExternalIP", Address: testInstanceOverrideAddress_external},
+				},
+				Region: testInstanceOverrideExternalRegion,
+			}},
+		},
+		LoadBalancer: loadBalancerConfig{},
+	}
+
+	// YAML
+	testConfigYAML_empty    = "---"
+	testConfigYAML_disabled = `---
+instances:
+  disabled: true
+loadBalancer:
+  disabled: true
+`
+	testConfigYAML_credsFile = fmt.Sprintf(`---
+global:
+  apiCredentialsFile: "%s"
+`, testAPICredentialsFile)
+	testConfigYAML_typical = fmt.Sprintf(`---
+global:
+  zone: "%s"
+  apiKey: "%s"
+  apiSecret: "%s"
+  apiEnvironment: "%s"
+`, testZone, testAPIKey, testAPISecret, testAPIEnvironment)
+)
+
+func (ts *exoscaleCCMTestSuite) Test_readExoscaleConfig_empty() {
+	os.Unsetenv("EXOSCALE_ZONE")
+	os.Unsetenv("EXOSCALE_API_KEY")
+	os.Unsetenv("EXOSCALE_API_SECRET")
+	os.Unsetenv("EXOSCALE_API_ENVIRONMENT")
+
+	cfg, err := readExoscaleConfig(strings.NewReader(testConfigYAML_empty))
+	ts.Require().NoError(err)
+	ts.Require().Equal("", cfg.Global.Zone)
+	ts.Require().Equal("", cfg.Global.ApiKey)
+	ts.Require().Equal("", cfg.Global.ApiSecret)
+	ts.Require().Equal("", cfg.Global.ApiCredentialsFile)
+	ts.Require().Equal(defaultComputeEnvironment, cfg.Global.ApiEnvironment)
+	ts.Require().Equal(false, cfg.Instances.Disabled)
+	ts.Require().Equal(false, cfg.LoadBalancer.Disabled)
+}
+
+func (ts *exoscaleCCMTestSuite) Test_readExoscaleConfig_env_credsFile() {
+	os.Setenv("EXOSCALE_API_CREDENTIALS_FILE", testAPICredentialsFile)
+	defer func() {
+		os.Unsetenv("EXOSCALE_API_CREDENTIALS_FILE")
+	}()
+
+	cfg, err := readExoscaleConfig(strings.NewReader(testConfigYAML_empty))
+	ts.Require().NoError(err)
+	ts.Require().Equal("", cfg.Global.ApiKey)
+	ts.Require().Equal("", cfg.Global.ApiSecret)
+	ts.Require().Equal(testAPICredentialsFile, cfg.Global.ApiCredentialsFile)
+}
+
+func (ts *exoscaleCCMTestSuite) Test_readExoscaleConfig_env_typical() {
+	os.Setenv("EXOSCALE_ZONE", testZone)
+	os.Setenv("EXOSCALE_API_KEY", testAPIKey)
+	os.Setenv("EXOSCALE_API_SECRET", testAPISecret)
+	os.Setenv("EXOSCALE_API_ENVIRONMENT", testAPIEnvironment)
+	defer func() {
+		os.Unsetenv("EXOSCALE_ZONE")
+		os.Unsetenv("EXOSCALE_API_KEY")
+		os.Unsetenv("EXOSCALE_API_SECRET")
+		os.Unsetenv("EXOSCALE_API_ENVIRONMENT")
+	}()
+
+	cfg, err := readExoscaleConfig(strings.NewReader(testConfigYAML_empty))
+	ts.Require().NoError(err)
+	ts.Require().Equal(testZone, cfg.Global.Zone)
+	ts.Require().Equal(testAPIKey, cfg.Global.ApiKey)
+	ts.Require().Equal(testAPISecret, cfg.Global.ApiSecret)
+	ts.Require().Equal("", cfg.Global.ApiCredentialsFile)
+	ts.Require().Equal(testAPIEnvironment, cfg.Global.ApiEnvironment)
+}
+
+func (ts *exoscaleCCMTestSuite) Test_readExoscaleConfig_disabled() {
+	cfg, err := readExoscaleConfig(strings.NewReader(testConfigYAML_disabled))
+	ts.Require().NoError(err)
+	ts.Require().Equal(true, cfg.Instances.Disabled)
+	ts.Require().Equal(true, cfg.LoadBalancer.Disabled)
+}
+
+func (ts *exoscaleCCMTestSuite) Test_readExoscaleConfig_credsFile() {
+	os.Unsetenv("EXOSCALE_API_CREDENTIALS_FILE")
+
+	cfg, err := readExoscaleConfig(strings.NewReader(testConfigYAML_credsFile))
+	ts.Require().NoError(err)
+	ts.Require().Equal("", cfg.Global.ApiKey)
+	ts.Require().Equal("", cfg.Global.ApiSecret)
+	ts.Require().Equal(testAPICredentialsFile, cfg.Global.ApiCredentialsFile)
+}
+
+func (ts *exoscaleCCMTestSuite) Test_readExoscaleConfig_typical() {
+	os.Unsetenv("EXOSCALE_ZONE")
+	os.Unsetenv("EXOSCALE_API_KEY")
+	os.Unsetenv("EXOSCALE_API_SECRET")
+	os.Unsetenv("EXOSCALE_API_ENVIRONMENT")
+
+	cfg, err := readExoscaleConfig(strings.NewReader(testConfigYAML_typical))
+	ts.Require().NoError(err)
+	ts.Require().Equal(testZone, cfg.Global.Zone)
+	ts.Require().Equal(testAPIKey, cfg.Global.ApiKey)
+	ts.Require().Equal(testAPISecret, cfg.Global.ApiSecret)
+	ts.Require().Equal("", cfg.Global.ApiCredentialsFile)
+	ts.Require().Equal(testAPIEnvironment, cfg.Global.ApiEnvironment)
+	ts.Require().Equal(false, cfg.Instances.Disabled)
+	ts.Require().Equal(false, cfg.LoadBalancer.Disabled)
+}

--- a/exoscale/exoscale_test.go
+++ b/exoscale/exoscale_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 var (
-	testZone       = "ch-gva-2"
 	testSeededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
@@ -24,14 +23,15 @@ type exoscaleCCMTestSuite struct {
 
 func (ts *exoscaleCCMTestSuite) SetupTest() {
 	ts.p = &cloudProvider{
+		cfg:     &testConfig_typical,
 		ctx:     context.Background(),
 		client:  new(exoscaleClientMock),
 		kclient: fake.NewSimpleClientset(),
 		zone:    testZone,
 	}
 
-	ts.p.instances = &instances{p: ts.p}
-	ts.p.loadBalancer = &loadBalancer{p: ts.p}
+	ts.p.instances = &instances{p: ts.p, cfg: &testConfig_typical.Instances}
+	ts.p.loadBalancer = &loadBalancer{p: ts.p, cfg: &testConfig_typical.LoadBalancer}
 	ts.p.zones = &zones{p: ts.p}
 }
 

--- a/exoscale/instances.go
+++ b/exoscale/instances.go
@@ -32,7 +32,8 @@ func newInstances(provider *cloudProvider, config *instancesConfig) cloudprovide
 // NodeAddresses returns the addresses of the specified instance.
 func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
 	// first look for a statically-configured override
-	if override := i.cfg.getInstanceOverride(nodeName); override != nil {
+	override := i.cfg.getInstanceOverride(nodeName)
+	if override != nil {
 		if n := len(override.Addresses); n > 0 {
 			nodeAddresses := make([]v1.NodeAddress, n)
 			for i, a := range override.Addresses {
@@ -67,7 +68,8 @@ func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) 
 // services cannot be used in this method to obtain nodeaddresses
 func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	// first look for a statically-configured override
-	if override := i.cfg.getInstanceOverrideByProviderID(providerID); override != nil {
+	override := i.cfg.getInstanceOverrideByProviderID(providerID)
+	if override != nil {
 		if n := len(override.Addresses); n > 0 {
 			nodeAddresses := make([]v1.NodeAddress, n)
 			for i, a := range override.Addresses {
@@ -107,7 +109,8 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 // TL;DR: ProviderID = "exoscale://<InstanceID>"
 func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	// first look for a statically-configured override
-	if override := i.cfg.getInstanceOverride(nodeName); override != nil {
+	override := i.cfg.getInstanceOverride(nodeName)
+	if override != nil {
 		if override.External {
 			if override.ExternalID != "" {
 				return override.ExternalID, nil
@@ -134,7 +137,8 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 // InstanceType returns the type of the specified instance.
 func (i *instances) InstanceType(ctx context.Context, nodeName types.NodeName) (string, error) {
 	// first look for a statically-configured override
-	if override := i.cfg.getInstanceOverride(nodeName); override != nil {
+	override := i.cfg.getInstanceOverride(nodeName)
+	if override != nil {
 		if override.Type != "" {
 			return override.Type, nil
 		} else if override.External {
@@ -158,7 +162,8 @@ func (i *instances) InstanceType(ctx context.Context, nodeName types.NodeName) (
 // InstanceTypeByProviderID returns the type of the specified instance.
 func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
 	// first look for a statically-configured override
-	if override := i.cfg.getInstanceOverrideByProviderID(providerID); override != nil {
+	override := i.cfg.getInstanceOverrideByProviderID(providerID)
+	if override != nil {
 		if override.Type != "" {
 			return override.Type, nil
 		} else if override.External {
@@ -201,7 +206,8 @@ func (i *instances) CurrentNodeName(_ context.Context, hostname string) (types.N
 // This method should still return true for instances that exist but are stopped/sleeping.
 func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
 	// first look for a statically-configured override
-	if override := i.cfg.getInstanceOverrideByProviderID(providerID); override != nil {
+	override := i.cfg.getInstanceOverrideByProviderID(providerID)
+	if override != nil {
 		if override.External {
 			return true, nil
 		}
@@ -227,7 +233,8 @@ func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID s
 // InstanceShutdownByProviderID returns true if the instance is shutdown in cloudprovider
 func (i *instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	// first look for a statically-configured override
-	if override := i.cfg.getInstanceOverrideByProviderID(providerID); override != nil {
+	override := i.cfg.getInstanceOverrideByProviderID(providerID)
+	if override != nil {
 		if override.External {
 			return false, cloudprovider.NotImplemented
 		}

--- a/exoscale/instances.go
+++ b/exoscale/instances.go
@@ -2,7 +2,6 @@ package exoscale
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"regexp"
@@ -115,7 +114,7 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 			if override.ExternalID != "" {
 				return override.ExternalID, nil
 			} else {
-				return fmt.Sprintf("external-%x", sha256.Sum256([]byte(override.Name))), nil
+				return defaultInstanceOverrideExternalID(override.Name), nil
 			}
 		}
 	}

--- a/exoscale/instances_config.go
+++ b/exoscale/instances_config.go
@@ -30,6 +30,10 @@ type instancesOverrideAddressConfig struct {
 	Address string
 }
 
+func defaultInstanceOverrideExternalID(overrideName string) string {
+	return fmt.Sprintf("external-%x", sha256.Sum256([]byte(overrideName)))
+}
+
 // Return statically-configured instance override
 func (c *instancesConfig) getInstanceOverride(nodeName types.NodeName) *instancesOverrideConfig {
 	var config *instancesOverrideConfig
@@ -72,7 +76,7 @@ func (c *instancesConfig) getInstanceOverrideByProviderID(providerID string) *in
 	// then try a match on the internally-built, name-based one
 	if config == nil {
 		for _, candidate := range c.Overrides {
-			if candidate.ExternalID == "" && instanceID == fmt.Sprintf("external-%x", sha256.Sum256([]byte(candidate.Name))) {
+			if candidate.ExternalID == "" && instanceID == defaultInstanceOverrideExternalID(candidate.Name) {
 				config = &candidate
 				break
 			}

--- a/exoscale/instances_config.go
+++ b/exoscale/instances_config.go
@@ -36,7 +36,7 @@ func (c *instancesConfig) getInstanceOverride(nodeName types.NodeName) *instance
 
 	// first try an exact match on name
 	for _, candidate := range c.Overrides {
-		if len(candidate.Name) != 0 && nodeName == types.NodeName(candidate.Name) {
+		if candidate.Name != "" && nodeName == types.NodeName(candidate.Name) {
 			config = &candidate
 			break
 		}
@@ -63,7 +63,7 @@ func (c *instancesConfig) getInstanceOverrideByProviderID(providerID string) *in
 
 	// first try an exact match on externalID
 	for _, candidate := range c.Overrides {
-		if len(candidate.ExternalID) != 0 && instanceID == candidate.ExternalID {
+		if candidate.ExternalID != "" && instanceID == candidate.ExternalID {
 			config = &candidate
 			break
 		}
@@ -72,7 +72,7 @@ func (c *instancesConfig) getInstanceOverrideByProviderID(providerID string) *in
 	// then try a match on the internally-built, name-based one
 	if config == nil {
 		for _, candidate := range c.Overrides {
-			if len(candidate.ExternalID) == 0 && instanceID == fmt.Sprintf("external-%x", sha256.Sum256([]byte(candidate.Name))) {
+			if candidate.ExternalID == "" && instanceID == fmt.Sprintf("external-%x", sha256.Sum256([]byte(candidate.Name))) {
 				config = &candidate
 				break
 			}

--- a/exoscale/instances_config.go
+++ b/exoscale/instances_config.go
@@ -50,7 +50,12 @@ func (c *instancesConfig) getInstanceOverride(nodeName types.NodeName) *instance
 	if config == nil {
 		for _, candidate := range c.Overrides {
 			if strings.HasPrefix(candidate.Name, "/") && strings.HasSuffix(candidate.Name, "/") {
-				if match, _ := regexp.Match(strings.Trim(candidate.Name, "/"), []byte(nodeName)); match {
+				match, err := regexp.Match(strings.Trim(candidate.Name, "/"), []byte(nodeName))
+				if err != nil {
+					errorf("invalid regular expression: %s", candidate.Name)
+					continue
+				}
+				if match {
 					config = &candidate
 					break
 				}

--- a/exoscale/instances_config.go
+++ b/exoscale/instances_config.go
@@ -1,0 +1,83 @@
+package exoscale
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Instances configuration (<-> cloud-config file)
+type instancesConfig struct {
+	Disabled     bool // if true, disables this controller
+	Overrides    []instancesOverrideConfig
+	ExternalOnly bool `yaml:"externalOnly"` // if true, ignore Exoscale API (use only static overrides, if any)
+}
+
+type instancesOverrideConfig struct {
+	Name       string // considered a regexp if '/.../'
+	External   bool
+	ExternalID string `yaml:"externalID"`
+	Type       string
+	Addresses  []instancesOverrideAddressConfig
+	Region     string
+}
+
+type instancesOverrideAddressConfig struct {
+	Type    string // Hostname, ExternalIP, InternalIP, ExternalDNS, InternalDNS (v1.NodeAddressType)
+	Address string
+}
+
+// Return statically-configured instance override
+func (c *instancesConfig) getInstanceOverride(nodeName types.NodeName) *instancesOverrideConfig {
+	var config *instancesOverrideConfig
+
+	// first try an exact match on name
+	for _, candidate := range c.Overrides {
+		if len(candidate.Name) != 0 && nodeName == types.NodeName(candidate.Name) {
+			config = &candidate
+			break
+		}
+	}
+
+	// then regexp match on "name"
+	if config == nil {
+		for _, candidate := range c.Overrides {
+			if strings.HasPrefix(candidate.Name, "/") && strings.HasSuffix(candidate.Name, "/") {
+				if match, _ := regexp.Match(strings.Trim(candidate.Name, "/"), []byte(nodeName)); match {
+					config = &candidate
+					break
+				}
+			}
+		}
+	}
+
+	return config
+}
+
+func (c *instancesConfig) getInstanceOverrideByProviderID(providerID string) *instancesOverrideConfig {
+	var config *instancesOverrideConfig
+	instanceID := strings.TrimPrefix(providerID, providerPrefix)
+
+	// first try an exact match on externalID
+	for _, candidate := range c.Overrides {
+		if len(candidate.ExternalID) != 0 && instanceID == candidate.ExternalID {
+			config = &candidate
+			break
+		}
+	}
+
+	// then try a match on the internally-built, name-based one
+	if config == nil {
+		for _, candidate := range c.Overrides {
+			if len(candidate.ExternalID) == 0 && instanceID == fmt.Sprintf("external-%x", sha256.Sum256([]byte(candidate.Name))) {
+				config = &candidate
+				break
+			}
+		}
+	}
+
+	return config
+}

--- a/exoscale/instances_config_test.go
+++ b/exoscale/instances_config_test.go
@@ -1,0 +1,160 @@
+package exoscale
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	// Overrides
+	testInstanceOverrideType = "testInstanceType"
+	testInstanceOverrideAddress_internal = "192.0.2.42"
+	testInstanceOverrideAddress_external = "203.0.113.42"
+	testInstanceOverrideExternalName = "testOverrideInstanceExternal"
+	testInstanceOverrideExternalID = "testInstanceExternalID"
+	testInstanceOverrideExternalType = "testInstanceTypeExternal"
+	testInstanceOverrideExternalRegion = "testInstanceRegionExternal"
+	testInstanceOverrideRegexpName = "/^testOverrideInstanceRegexp.*/"
+	testInstanceOverrideRegexpNodeName = "testOverrideInstanceRegexpF00b@r"
+	testInstanceOverrideRegexpInstanceID = fmt.Sprintf("external-%x", sha256.Sum256([]byte(testInstanceOverrideRegexpName)))
+	testInstanceOverrideRegexpProviderID = fmt.Sprintf("%s://%s", ProviderName, testInstanceOverrideRegexpInstanceID)
+
+	// YAML
+	testConfigYAML_instances = fmt.Sprintf(`---
+global:
+  zone: "%s"
+  apiKey: "%s"
+  apiSecret: "%s"
+instances:
+  overrides:
+    - name: "testOverrideInstanceType"
+      type: "%s"
+    - name: "testOverrideInstanceAddresses"
+      addresses:
+        - type: InternalIP
+          address: "%s"
+        - type: ExternalIP
+          address: "%s"
+    - name: "%s"
+      external: true
+      externalID: "%s"
+      type: "%s"
+      region: "%s"
+    - name: "%s"
+      external: true
+`,
+		testZone, testAPIKey, testAPISecret,
+		testInstanceOverrideType,
+		testInstanceOverrideAddress_internal, testInstanceOverrideAddress_external,
+		testInstanceOverrideExternalName, testInstanceOverrideExternalID, testInstanceOverrideExternalType, testInstanceOverrideExternalRegion,
+		testInstanceOverrideRegexpName,
+	)
+)
+
+func (ts *exoscaleCCMTestSuite) Test_readExoscaleConfig_instances() {
+	os.Unsetenv("EXOSCALE_ZONE")
+	os.Unsetenv("EXOSCALE_API_KEY")
+	os.Unsetenv("EXOSCALE_API_SECRET")
+
+	cfg, err := readExoscaleConfig(strings.NewReader(testConfigYAML_instances))
+
+	// Global
+	ts.Require().NoError(err)
+	ts.Require().Equal(testZone, cfg.Global.Zone)
+	ts.Require().Equal(testAPIKey, cfg.Global.ApiKey)
+	ts.Require().Equal(testAPISecret, cfg.Global.ApiSecret)
+	ts.Require().Equal(defaultComputeEnvironment, cfg.Global.ApiEnvironment)
+
+	// Overrides
+	ts.Require().Equal(4, len(cfg.Instances.Overrides))
+
+	// empty
+	{
+		override := cfg.Instances.getInstanceOverride("")
+		ts.Require().Nil(override)
+	}
+	{
+		override := cfg.Instances.getInstanceOverrideByProviderID("")
+		ts.Require().Nil(override)
+	}
+
+	// invalid
+	{
+		override := cfg.Instances.getInstanceOverride("invalidNodeName")
+		ts.Require().Nil(override)
+	}
+	{
+		override := cfg.Instances.getInstanceOverrideByProviderID("invalidProviderID")
+		ts.Require().Nil(override)
+	}
+
+	// testOverrideInstanceType
+	{
+		override := cfg.Instances.getInstanceOverride("testOverrideInstanceType")
+		ts.Require().NotNil(override)
+		ts.Require().Equal(false, override.External)
+		ts.Require().Equal("", override.ExternalID)
+		ts.Require().Equal(testInstanceOverrideType, override.Type)
+		ts.Require().Equal(0, len(override.Addresses))
+		ts.Require().Equal("", override.Region)
+	}
+
+	// testOverrideInstanceAddresses
+	{
+		override := cfg.Instances.getInstanceOverride("testOverrideInstanceAddresses")
+		ts.Require().NotNil(override)
+		ts.Require().Equal(false, override.External)
+		ts.Require().Equal("", override.ExternalID)
+		ts.Require().Equal("", override.Type)
+		ts.Require().Equal(2, len(override.Addresses))
+		ts.Require().Equal("InternalIP", override.Addresses[0].Type)
+		ts.Require().Equal(testInstanceOverrideAddress_internal, override.Addresses[0].Address)
+		ts.Require().Equal("ExternalIP", override.Addresses[1].Type)
+		ts.Require().Equal(testInstanceOverrideAddress_external, override.Addresses[1].Address)
+		ts.Require().Equal("", override.Region)
+	}
+
+	// testOverrideInstanceExternal
+	{
+		override := cfg.Instances.getInstanceOverride(types.NodeName(testInstanceOverrideExternalName))
+		ts.Require().NotNil(override)
+		ts.Require().Equal(true, override.External)
+		ts.Require().Equal(testInstanceOverrideExternalID, override.ExternalID)
+		ts.Require().Equal(testInstanceOverrideExternalType, override.Type)
+		ts.Require().Equal(0, len(override.Addresses))
+		ts.Require().Equal(testInstanceOverrideExternalRegion, override.Region)
+	}
+	{
+		override := cfg.Instances.getInstanceOverrideByProviderID(testInstanceOverrideExternalID)
+		ts.Require().NotNil(override)
+		ts.Require().Equal(true, override.External)
+		ts.Require().Equal(testInstanceOverrideExternalID, override.ExternalID)
+		ts.Require().Equal(testInstanceOverrideExternalType, override.Type)
+		ts.Require().Equal(0, len(override.Addresses))
+		ts.Require().Equal(testInstanceOverrideExternalRegion, override.Region)
+	}
+
+	// testOverrideInstanceRegexp
+	{
+		override := cfg.Instances.getInstanceOverride(types.NodeName(testInstanceOverrideRegexpNodeName))
+		ts.Require().NotNil(override)
+		ts.Require().Equal(true, override.External)
+		ts.Require().Equal("", override.ExternalID)
+		ts.Require().Equal("", override.Type)
+		ts.Require().Equal(0, len(override.Addresses))
+		ts.Require().Equal("", override.Region)
+	}
+	{
+		override := cfg.Instances.getInstanceOverrideByProviderID(testInstanceOverrideRegexpProviderID)
+		ts.Require().NotNil(override)
+		ts.Require().Equal(true, override.External)
+		ts.Require().Equal("", override.ExternalID)
+		ts.Require().Equal("", override.Type)
+		ts.Require().Equal(0, len(override.Addresses))
+		ts.Require().Equal("", override.Region)
+	}
+}

--- a/exoscale/instances_test.go
+++ b/exoscale/instances_test.go
@@ -316,3 +316,56 @@ func (ts *exoscaleCCMTestSuite) TestInstanceShutdownByProviderID() {
 	ts.Require().NoError(err)
 	ts.Require().True(shutdown)
 }
+
+// Statically-configured overrides
+func (ts *exoscaleCCMTestSuite) TestNodeAddresses_overrideExternal() {
+	expected := []v1.NodeAddress{
+		{Type:    v1.NodeInternalIP, Address: testInstanceOverrideAddress_internal},
+		{Type:    v1.NodeExternalIP, Address: testInstanceOverrideAddress_external},
+	}
+
+	actual, err := ts.p.instances.NodeAddresses(ts.p.ctx, types.NodeName(testInstanceOverrideRegexpNodeName))
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *exoscaleCCMTestSuite) TestNodeAddressesByProviderID_overrideExternal() {
+	expected := []v1.NodeAddress{
+		{Type:    v1.NodeInternalIP, Address: testInstanceOverrideAddress_internal},
+		{Type:    v1.NodeExternalIP, Address: testInstanceOverrideAddress_external},
+	}
+
+	actual, err := ts.p.instances.NodeAddressesByProviderID(ts.p.ctx, testInstanceOverrideRegexpProviderID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *exoscaleCCMTestSuite) TestInstanceID_overrideExternal() {
+	actual, err := ts.p.instances.InstanceID(ts.p.ctx, types.NodeName(testInstanceOverrideRegexpNodeName))
+	ts.Require().NoError(err)
+	ts.Require().Equal(actual, testInstanceOverrideRegexpInstanceID)
+}
+
+func (ts *exoscaleCCMTestSuite) TestInstanceType_overrideExternal() {
+	actual, err := ts.p.instances.InstanceType(ts.p.ctx, types.NodeName(testInstanceOverrideRegexpNodeName))
+	ts.Require().NoError(err)
+	ts.Require().Equal(actual, testInstanceOverrideExternalType)
+}
+
+func (ts *exoscaleCCMTestSuite) TestInstanceTypeByProviderID_overrideExternal() {
+	actual, err := ts.p.instances.InstanceTypeByProviderID(ts.p.ctx, testInstanceOverrideRegexpProviderID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(actual, testInstanceOverrideExternalType)
+}
+
+func (ts *exoscaleCCMTestSuite) TestInstanceExistsByProviderID_overrideExternal() {
+	exists, err := ts.p.instances.InstanceExistsByProviderID(ts.p.ctx, testInstanceOverrideRegexpProviderID)
+	ts.Require().NoError(err)
+	ts.Require().True(exists)
+}
+
+func (ts *exoscaleCCMTestSuite) TestInstanceShutdownByProviderID_overrideExternal() {
+	shutdown, err := ts.p.instances.InstanceShutdownByProviderID(ts.p.ctx, testInstanceOverrideRegexpProviderID)
+	ts.Require().Equal(cloudprovider.NotImplemented, err)
+	ts.Require().False(shutdown)
+}

--- a/exoscale/loadbalancer.go
+++ b/exoscale/loadbalancer.go
@@ -44,7 +44,8 @@ var (
 var errLoadBalancerNotFound = errors.New("load balancer not found")
 
 type loadBalancer struct {
-	p *cloudProvider
+	p   *cloudProvider
+	cfg *loadBalancerConfig
 }
 
 // isExternal returns true if the NLB instance is marked as "external" in the
@@ -53,8 +54,11 @@ func (l loadBalancer) isExternal(service *v1.Service) bool {
 	return strings.ToLower(*getAnnotation(service, annotationLoadBalancerExternal, "false")) == "true"
 }
 
-func newLoadBalancer(provider *cloudProvider) cloudprovider.LoadBalancer {
-	return &loadBalancer{p: provider}
+func newLoadBalancer(provider *cloudProvider, config *loadBalancerConfig) cloudprovider.LoadBalancer {
+	return &loadBalancer{
+		p:   provider,
+		cfg: config,
+	}
 }
 
 // GetLoadBalancer returns whether the specified load balancer exists, and

--- a/exoscale/loadbalancer_config.go
+++ b/exoscale/loadbalancer_config.go
@@ -1,0 +1,6 @@
+package exoscale
+
+// LoadBalancer configuration (<-> cloud-config file)
+type loadBalancerConfig struct {
+	Disabled bool // if true, disables this controller
+}

--- a/exoscale/loadbalancer_test.go
+++ b/exoscale/loadbalancer_test.go
@@ -38,8 +38,8 @@ var (
 )
 
 func (ts *exoscaleCCMTestSuite) Test_newLoadBalancer() {
-	actual := newLoadBalancer(ts.p)
-	ts.Require().Equal(actual, &loadBalancer{p: ts.p})
+	actual := newLoadBalancer(ts.p, &testConfig_typical.LoadBalancer)
+	ts.Require().Equal(actual, &loadBalancer{p: ts.p, cfg: &testConfig_typical.LoadBalancer})
 }
 
 func (ts *exoscaleCCMTestSuite) Test_loadBalancer_isExternal() {

--- a/exoscale/zones.go
+++ b/exoscale/zones.go
@@ -35,7 +35,23 @@ func (z zones) GetZone(_ context.Context) (cloudprovider.Zone, error) {
 // GetZoneByProviderID returns the Zone containing the current zone and locality region of the node specified by
 // providerID. This method is particularly used in the context of external cloud providers where node initialization
 // must be done outside the kubelets.
-func (z *zones) GetZoneByProviderID(_ context.Context, _ string) (cloudprovider.Zone, error) {
+func (z *zones) GetZoneByProviderID(_ context.Context, providerID string) (cloudprovider.Zone, error) {
+	// first look for a statically-configured override
+	if override := z.p.cfg.Instances.getInstanceOverrideByProviderID(providerID); override != nil {
+		if override.External {
+			if len(override.Region) != 0 {
+				return cloudprovider.Zone{Region: override.Region}, nil
+			} else {
+				return cloudprovider.Zone{Region: "external"}, nil
+			}
+		}
+	}
+
+	// Use Exoscale API ?
+	if z.p.cfg.Instances.ExternalOnly {
+		return cloudprovider.Zone{}, fmt.Errorf("no instance override found (Exoscale API disabled)")
+	}
+
 	// The Exoscale is set at Cloud Controller Manager level, cluster Nodes cannot be in a different zone.
 	return cloudprovider.Zone{Region: z.p.zone}, nil
 }
@@ -44,6 +60,22 @@ func (z *zones) GetZoneByProviderID(_ context.Context, _ string) (cloudprovider.
 // name. This method is particularly used in the context of external cloud providers where node initialization must
 // be done outside the kubelets.
 func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
+	// first look for a statically-configured override
+	if override := z.p.cfg.Instances.getInstanceOverride(nodeName); override != nil {
+		if override.External {
+			if len(override.Region) != 0 {
+				return cloudprovider.Zone{Region: override.Region}, nil
+			} else {
+				return cloudprovider.Zone{Region: "external"}, nil
+			}
+		}
+	}
+
+	// Use Exoscale API ?
+	if z.p.cfg.Instances.ExternalOnly {
+		return cloudprovider.Zone{}, fmt.Errorf("no instance override found (Exoscale API disabled)")
+	}
+
 	node, err := z.p.kclient.CoreV1().Nodes().Get(ctx, string(nodeName), metav1.GetOptions{})
 	if err != nil {
 		return cloudprovider.Zone{}, fmt.Errorf(

--- a/exoscale/zones.go
+++ b/exoscale/zones.go
@@ -37,7 +37,8 @@ func (z zones) GetZone(_ context.Context) (cloudprovider.Zone, error) {
 // must be done outside the kubelets.
 func (z *zones) GetZoneByProviderID(_ context.Context, providerID string) (cloudprovider.Zone, error) {
 	// first look for a statically-configured override
-	if override := z.p.cfg.Instances.getInstanceOverrideByProviderID(providerID); override != nil {
+	override := z.p.cfg.Instances.getInstanceOverrideByProviderID(providerID)
+	if override != nil {
 		if override.External {
 			if override.Region != "" {
 				return cloudprovider.Zone{Region: override.Region}, nil
@@ -61,7 +62,8 @@ func (z *zones) GetZoneByProviderID(_ context.Context, providerID string) (cloud
 // be done outside the kubelets.
 func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
 	// first look for a statically-configured override
-	if override := z.p.cfg.Instances.getInstanceOverride(nodeName); override != nil {
+	override := z.p.cfg.Instances.getInstanceOverride(nodeName)
+	if override != nil {
 		if override.External {
 			if override.Region != "" {
 				return cloudprovider.Zone{Region: override.Region}, nil

--- a/exoscale/zones.go
+++ b/exoscale/zones.go
@@ -39,7 +39,7 @@ func (z *zones) GetZoneByProviderID(_ context.Context, providerID string) (cloud
 	// first look for a statically-configured override
 	if override := z.p.cfg.Instances.getInstanceOverrideByProviderID(providerID); override != nil {
 		if override.External {
-			if len(override.Region) != 0 {
+			if override.Region != "" {
 				return cloudprovider.Zone{Region: override.Region}, nil
 			} else {
 				return cloudprovider.Zone{Region: "external"}, nil
@@ -63,7 +63,7 @@ func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) 
 	// first look for a statically-configured override
 	if override := z.p.cfg.Instances.getInstanceOverride(nodeName); override != nil {
 		if override.External {
-			if len(override.Region) != 0 {
+			if override.Region != "" {
 				return cloudprovider.Zone{Region: override.Region}, nil
 			} else {
 				return cloudprovider.Zone{Region: "external"}, nil

--- a/exoscale/zones_test.go
+++ b/exoscale/zones_test.go
@@ -75,3 +75,19 @@ func (ts *exoscaleCCMTestSuite) TestGetZoneByNodeName() {
 	ts.Require().NoError(err)
 	ts.Require().Equal(expected, actual)
 }
+
+func (ts *exoscaleCCMTestSuite) TestGetZoneByProviderID_overrideExternal() {
+	expected := cloudprovider.Zone{Region: testInstanceOverrideExternalRegion}
+
+	actual, err := ts.p.zones.GetZoneByProviderID(ts.p.ctx, testInstanceOverrideRegexpProviderID)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}
+
+func (ts *exoscaleCCMTestSuite) TestGetZoneByNodeName_overrideExternal() {
+	expected := cloudprovider.Zone{Region: testInstanceOverrideExternalRegion}
+
+	actual, err := ts.p.zones.GetZoneByNodeName(ts.p.ctx, types.NodeName(testInstanceOverrideRegexpNodeName))
+	ts.Require().NoError(err)
+	ts.Require().Equal(expected, actual)
+}

--- a/integtest/test-csr-validation.bash
+++ b/integtest/test-csr-validation.bash
@@ -11,9 +11,11 @@ echo "### Adding a Node to the cluster ..."
 exo compute instance-pool scale -f -z $EXOSCALE_ZONE $NODEPOOL_ID 2 > /dev/null
 
 _until_success "test \$(kubectl get nodes --no-headers -l '!node-role.kubernetes.io/master' | grep '^test-\S*-pool-' | wc -l) -ge 2"
+_until_success "test \$(kubectl get nodes --no-headers -l '!node-role.kubernetes.io/master' | grep '^test-\S*-external\s' | wc -l) -ge 1"
 
 echo "### Checking that the Node CSR got approved ..."
 
 _until_success "test \$(kubectl get csr --no-headers | grep '\ssystem:node:test-\S*-pool-\S.*\sApproved' | wc -l) -ge 2"
+_until_success "test \$(kubectl get csr --no-headers | grep '\ssystem:node:test-\S*-external\s.*\sApproved' | wc -l) -ge 1"
 
 echo "<<< PASS"

--- a/integtest/test-init.bash
+++ b/integtest/test-init.bash
@@ -54,7 +54,7 @@ echo "### Checking control-plane availability ..."
 _until_success "kubectl cluster-info"
 
 echo "### Waiting for (and approving) node CSRs ..."
-_until_success "test \$(kubectl get csr --field-selector spec.signerName=kubernetes.io/kubelet-serving -o name | wc -l) -ge 2"
+_until_success "test \$(kubectl get csr --field-selector spec.signerName=kubernetes.io/kubelet-serving -o name | wc -l) -ge 3"
 kubectl certificate approve $(kubectl get csr --field-selector spec.signerName=kubernetes.io/kubelet-serving -o name)
 
 echo "<<< DONE"

--- a/integtest/test-nlb-external.bash
+++ b/integtest/test-nlb-external.bash
@@ -12,7 +12,7 @@ kubectl $KUBECTL_OPTS apply -f "${INTEGTEST_TMP_DIR}/manifests/hello-no-ingress.
 ### Test the actual NLB + service + app chain
 echo "### Checking end-to-end requests ..."
 curl_opts="--retry 10 --retry-delay 10 --retry-connrefused --silent"
-curl $curl_opts http://${EXTERNAL_NLB_IP} > /dev/null || (echo "FAIL" ; return 1)
+curl $curl_opts http://${EXTERNAL_NLB_IP} > /dev/null || (echo "!!! FAIL" >&2 ; return 1)
 
 ### Test the external NLB instance properties
 output_template=''
@@ -32,7 +32,7 @@ while read l; do
   case "${k}" in
     Name) _assert_string_equal "$v" "$EXTERNAL_NLB_NAME" ;;
     Description) _assert_string_equal "$v" "$EXTERNAL_NLB_DESC" ;;
-    *) echo "ERROR: unexpected key \"$k\"" ; exit 1 ;;
+    *) echo "!!! ERROR: unexpected key \"$k\"" >&2 ; exit 1 ;;
   esac
 done < "${INTEGTEST_TMP_DIR}/external_nlb"
 

--- a/integtest/test-nlb-ingress.bash
+++ b/integtest/test-nlb-ingress.bash
@@ -27,8 +27,8 @@ kubectl $KUBECTL_OPTS wait --for condition=Available deployment.apps/hello
 ### Test the actual NLB + ingress-nginx controller + service + app chain
 echo "### Checking end-to-end requests ..."
 curl_opts="--retry 10 --retry-delay 5 --retry-connrefused --silent"
-curl $curl_opts http://${INGRESS_NLB_IP} > /dev/null || (echo "FAIL" ; return 1)
-curl $curl_opts --insecure https://${INGRESS_NLB_IP} > /dev/null || (echo "FAIL" ; return 1)
+curl $curl_opts http://${INGRESS_NLB_IP} > /dev/null || (echo "!!! FAIL" >&2 ; return 1)
+curl $curl_opts --insecure https://${INGRESS_NLB_IP} > /dev/null || (echo "!!! FAIL" >&2 ; return 1)
 
 ### Test the generated NLB services' properties
 output_template=''
@@ -61,7 +61,7 @@ exo compute load-balancer show \
       export INGRESS_NLB_SERVICE_HTTPS_ID=$svcid
       ;;
     *)
-      echo "ERROR: unexpected service port $svcport, expected either 80 or 443"
+      echo "!!! ERROR: unexpected service port $svcport, expected either 80 or 443" >&2
       exit 1
       ;;
     esac
@@ -83,7 +83,7 @@ while read l; do
     HealthcheckInterval) _assert_string_equal "$v" "10s" ;;
     HealthcheckTimeout) _assert_string_equal "$v" "5s" ;;
     HealthcheckRetries) _assert_string_equal "$v" "1" ;;
-    *) echo "ERROR: unexpected key \"$k\"" ; exit 1 ;;
+    *) echo "!!! ERROR: unexpected key \"$k\"" >&2 ; exit 1 ;;
   esac
 done < "${INTEGTEST_TMP_DIR}/nlb_service_http"
 
@@ -103,7 +103,7 @@ while read l; do
     HealthcheckInterval) _assert_string_equal "$v" "10s" ;;
     HealthcheckTimeout) _assert_string_equal "$v" "5s" ;;
     HealthcheckRetries) _assert_string_equal "$v" "1" ;;
-    *) echo "ERROR: unexpected key \"$k\"" ; exit 1 ;;
+    *) echo "!!! ERROR: unexpected key \"$k\"" >&2 ; exit 1 ;;
   esac
 done < "${INTEGTEST_TMP_DIR}/nlb_service_https"
 

--- a/integtest/test-node-labels.bash
+++ b/integtest/test-node-labels.bash
@@ -6,13 +6,15 @@ source "$INTEGTEST_DIR/test-helpers.bash"
 
 echo ">>> TESTING CCM-MANAGED KUBERNETES NODE LABELS"
 
-export NODEPOOL_INSTANCE_NAME=$(kubectl get nodes \
-  -o jsonpath={.items[].metadata.name} -l 'node-role.kubernetes.io/master!=')
+echo "### Checking instance pool node labels ..."
 
-kubectl get node $NODEPOOL_INSTANCE_NAME \
+export NODEPOOL_INSTANCE_NAME=$(kubectl get nodes -o name | sed -nE 's|^node/(test-\S*-pool-.*)$|\1|p;T next;q;:next')
+
+kubectl get node ${NODEPOOL_INSTANCE_NAME} \
   -o=go-template='{{range $k, $v := .metadata.labels}}{{$k}}={{println $v}}{{end}}' \
   > "${INTEGTEST_TMP_DIR}/nodepool_labels"
 
+unset EXPECTED
 declare -A EXPECTED
 EXPECTED[kubernetes.io/hostname]="$NODEPOOL_INSTANCE_NAME"
 EXPECTED[beta.kubernetes.io/instance-type]="medium"
@@ -20,6 +22,7 @@ EXPECTED[node.kubernetes.io/instance-type]="medium"
 EXPECTED[failure-domain.beta.kubernetes.io/region]="$EXOSCALE_ZONE"
 EXPECTED[topology.kubernetes.io/region]="$EXOSCALE_ZONE"
 
+nodepool_labels_n=0
 while read l; do
   # Split "k=v" formatted line into variables $k and $v
   k=${l%=*} v=${l#*=}
@@ -31,6 +34,46 @@ while read l; do
     echo "FAIL: Node label $k: expected \"${EXPECTED[$k]}\", got \"$v\""
     exit 1
   fi
+  (( nodepool_labels_n++ )) || true
 done < "${INTEGTEST_TMP_DIR}/nodepool_labels"
+if [[ "${nodepool_labels_n}" -ne "${#EXPECTED[*]}" ]]; then
+    echo "FAIL: Missing node labels: expected ${#EXPECTED[*]}, got ${nodepool_labels_n}"
+    exit 1
+fi
+
+echo "### Checking external node labels ..."
+
+export EXTERNAL_INSTANCE_NAME=$(kubectl get nodes -o name | sed -nE 's|^node/(test-\S*-external)$|\1|p;T next;q;:next')
+
+kubectl get node ${EXTERNAL_INSTANCE_NAME} \
+  -o=go-template='{{range $k, $v := .metadata.labels}}{{$k}}={{println $v}}{{end}}' \
+  > "${INTEGTEST_TMP_DIR}/external_labels"
+
+unset EXPECTED
+declare -A EXPECTED
+EXPECTED[kubernetes.io/hostname]="$EXTERNAL_INSTANCE_NAME"
+EXPECTED[beta.kubernetes.io/instance-type]="externalType"
+EXPECTED[node.kubernetes.io/instance-type]="externalType"
+EXPECTED[failure-domain.beta.kubernetes.io/region]="externalRegion"
+EXPECTED[topology.kubernetes.io/region]="externalRegion"
+
+external_labels_n=0
+while read l; do
+  # Split "k=v" formatted line into variables $k and $v
+  k=${l%=*} v=${l#*=}
+
+  # Ignore labels not managed by the Exoscale CCM
+  [[ -z "${EXPECTED[$k]}" ]] && continue
+
+  if [[ "$v" != "${EXPECTED[$k]}" ]]; then
+    echo "FAIL: Node label $k: expected \"${EXPECTED[$k]}\", got \"$v\""
+    exit 1
+  fi
+  (( external_labels_n++ )) || true
+done < "${INTEGTEST_TMP_DIR}/external_labels"
+if [[ "${external_labels_n}" -ne "${#EXPECTED[*]}" ]]; then
+    echo "FAIL: Missing node labels: expected ${#EXPECTED[*]}, got ${external_labels_n}"
+    exit 1
+fi
 
 echo "<<< PASS"

--- a/integtest/test-node-labels.bash
+++ b/integtest/test-node-labels.bash
@@ -31,13 +31,13 @@ while read l; do
   [[ -z "${EXPECTED[$k]}" ]] && continue
 
   if [[ "$v" != "${EXPECTED[$k]}" ]]; then
-    echo "FAIL: Node label $k: expected \"${EXPECTED[$k]}\", got \"$v\""
+    echo "!!! FAIL: Node label $k: expected \"${EXPECTED[$k]}\", got \"$v\"" >&2
     exit 1
   fi
   (( nodepool_labels_n++ )) || true
 done < "${INTEGTEST_TMP_DIR}/nodepool_labels"
 if [[ "${nodepool_labels_n}" -ne "${#EXPECTED[*]}" ]]; then
-    echo "FAIL: Missing node labels: expected ${#EXPECTED[*]}, got ${nodepool_labels_n}"
+    echo "!!! FAIL: Missing node labels: expected ${#EXPECTED[*]}, got ${nodepool_labels_n}" >&2
     exit 1
 fi
 
@@ -66,13 +66,13 @@ while read l; do
   [[ -z "${EXPECTED[$k]}" ]] && continue
 
   if [[ "$v" != "${EXPECTED[$k]}" ]]; then
-    echo "FAIL: Node label $k: expected \"${EXPECTED[$k]}\", got \"$v\""
+    echo "!!! FAIL: Node label $k: expected \"${EXPECTED[$k]}\", got \"$v\"" >&2
     exit 1
   fi
   (( external_labels_n++ )) || true
 done < "${INTEGTEST_TMP_DIR}/external_labels"
 if [[ "${external_labels_n}" -ne "${#EXPECTED[*]}" ]]; then
-    echo "FAIL: Missing node labels: expected ${#EXPECTED[*]}, got ${external_labels_n}"
+    echo "!!! FAIL: Missing node labels: expected ${#EXPECTED[*]}, got ${external_labels_n}" >&2
     exit 1
 fi
 

--- a/integtest/test.tf
+++ b/integtest/test.tf
@@ -239,6 +239,19 @@ resource "exoscale_instance_pool" "test" {
   #depends_on = [exoscale_compute_instance.kube_master_node]
 }
 
+resource "exoscale_compute_instance" "external" {
+  zone               = var.zone
+  name               = "${local.test_prefix}-${random_string.random.result}-external"
+  type               = "standard.medium"
+  template_id        = data.exoscale_compute_template.coi.id
+  disk_size          = 15
+  security_group_ids = [exoscale_security_group.test.id]
+  ssh_key            = exoscale_ssh_key.test.name
+  user_data          = data.template_file.kubenode_userdata.rendered
+
+  #depends_on = [exoscale_compute_instance.kube_master_node]
+}
+
 resource "exoscale_nlb" "external" {
   zone        = var.zone
   name        = "${local.test_prefix}-${random_string.random.result}"
@@ -251,6 +264,8 @@ output "test_id" { value = random_string.random.result }
 output "master_node_id" { value = exoscale_compute_instance.kube_master_node.id }
 output "master_node_ip" { value = exoscale_compute_instance.kube_master_node.public_ip_address }
 output "nodepool_id" { value = exoscale_instance_pool.test.id }
+output "external_node_id" { value = exoscale_compute_instance.external.id }
+output "external_node_ip" { value = exoscale_compute_instance.external.public_ip_address }
 output "external_nlb_id" { value = exoscale_nlb.external.id }
 output "external_nlb_ip" { value = exoscale_nlb.external.ip_address }
 output "external_nlb_name" { value = exoscale_nlb.external.name }


### PR DESCRIPTION
## Testing done

```
* [go-1.17.8] cdufour@xps13-9380.cedric.exoscale.me:~/git/exoscale/exoscale-cloud-controller-manager (cedric/sc-45779/ccm-config-override)
$ make test
'/opt/cdufour/go/1.17.8/bin/go' test \
  -race \
  -mod vendor \
  -timeout 15s \
   \
  github.com/exoscale/exoscale-cloud-controller-manager/exoscale
ok  	github.com/exoscale/exoscale-cloud-controller-manager/exoscale	(cached)

$ _EE_acc make test-integration | grep -E '(<<<|###|>>>|===|!!!)'
>>> DEPLOYING TEST CLUSTER INFRASTRUCTURE
exoscale_compute_instance.kube_master_node (remote-exec): ### Installing OS dependencies ...
exoscale_compute_instance.kube_master_node (remote-exec): ### Building Exoscale Cloud-Controller Manager (CCM) image ...
exoscale_compute_instance.kube_master_node (remote-exec): ### Bootstrapping Kubernetes control-plane ...
exoscale_compute_instance.kube_master_node (local-exec): ### Copying Kubernetes configuration resources ...
exoscale_compute_instance.kube_master_node (local-exec): ### Dumping Kubernetes control-plane resources ...
exoscale_compute_instance.kube_master_node (local-exec): ### Installing Calico ...
exoscale_compute_instance.kube_master_node (local-exec): ### Waiting for Kubernetes control-plane to be ready ...
exoscale_compute_instance.kube_master_node (local-exec): ### Installing Exoscale Cloud-Controller Manager (CCM) ...
exoscale_compute_instance.kube_master_node (local-exec): ### Waiting for Exoscale Cloud-Controller Manager (CCM) to be ready ...
### Checking control-plane availability ...
### Waiting for (and approving) node CSRs ...
<<< DONE
>>> TESTING API CREDENTIALS FILE RELOADING
### Checking initial API credentials ...
### Refreshing API credentials ...
<<< PASS
>>> TESTING SKS AGENT NODE CSR VALIDATION
### Adding a Node to the cluster ...
 ✔ Scaling Instance Pool "bfda0684-d0d2-4ee3-8c48-586450ef03fc"... 18s
### Checking that the Node CSR got approved ...
<<< PASS
>>> TESTING CCM-MANAGED KUBERNETES NODE LABELS
### Checking instance pool node labels ...
### Checking external node labels ...
<<< PASS
>>> TESTING CCM-MANAGED NLB INSTANCE
### Deploying cluster ingress controller ...
### Deploying test application ...
### Checking end-to-end requests ...
### Checking ingress HTTP NLB service properties ...
### Checking ingress HTTPS NLB service properties ...
### Updating ingress NLB services ...
### Destroying test application ...
### Deleting ingress NLB ...
<<< PASS
>>> TESTING CCM WITH EXTERNAL NLB INSTANCE
### Deploying Service ...
### Checking end-to-end requests ...
### Checking external NLB instance properties ...
### Delete Service and keep external NLB instance ...
<<< PASS
>>> TESTING CCM-MANAGED NODE EXPUNGING
<<< PASS
=== ALL TESTS PASSED ===
>>> CLEANING UP
<<< DONE
@ 2022-04-28 11:50:25 +0200
```