### PR TITLE
Fix nil NLB-id crash

### DIFF
--- a/exoscale/loadbalancer.go
+++ b/exoscale/loadbalancer.go
@@ -42,6 +42,7 @@ var (
 )
 
 var errLoadBalancerNotFound = errors.New("load balancer not found")
+var errLoadBalancerIDAnnotationNotFound = errors.New("load balancer ID annotation not found")
 
 type loadBalancer struct {
 	p   *cloudProvider
@@ -241,6 +242,11 @@ func (l *loadBalancer) updateLoadBalancer(ctx context.Context, service *v1.Servi
 	nlbUpdate, err := buildLoadBalancerFromAnnotations(service)
 	if err != nil {
 		return err
+	}
+
+
+	if nlbUpdate.ID == nil {
+		return errLoadBalancerIDAnnotationNotFound
 	}
 
 	nlbCurrent, err := l.p.client.GetNetworkLoadBalancer(ctx, l.p.zone, *nlbUpdate.ID)


### PR DESCRIPTION
Under some circumstances, a crash can happen because of a missing NLB id annotation.

Example stack trace:

```
E0701 08:18:11.056538  802594 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 347 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1ac2180?, 0x2efded0})
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0006c8d20?})
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1ac2180, 0x2efded0})
	/home/phil/opt/go/1.18/src/runtime/panic.go:838 +0x207
github.com/exoscale/exoscale-cloud-controller-manager/exoscale.(*loadBalancer).updateLoadBalancer(0xc00034e990, {0x20668f8, 0xc0000520f8}, 0xc000678a01?)
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/exoscale/loadbalancer.go:246 +0x84
github.com/exoscale/exoscale-cloud-controller-manager/exoscale.(*loadBalancer).UpdateLoadBalancer(0xc0006c8c60?, {0x20668f8?, 0xc0000520f8?}, {0x2f2b7e0?, 0xc000819cd0?}, 0x0?, {0x0?, 0x0?, 0x7fba36349f40?})
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/exoscale/loadbalancer.go:186 +0x26
k8s.io/cloud-provider/controllers/service.(*Controller).lockedUpdateLoadBalancerHosts(0xc00062e0e0, 0xc0005444b0, {0xc00041bee0?, 0x2, 0x2})
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/cloud-provider/controllers/service/controller.go:824 +0x2fa
k8s.io/cloud-provider/controllers/service.(*Controller).nodeSyncService(0xc00062e0e0, 0xc0005444b0)
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/cloud-provider/controllers/service/controller.go:780 +0x259
k8s.io/cloud-provider/controllers/service.(*Controller).updateLoadBalancerHosts.func1(0x0)
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/cloud-provider/controllers/service/controller.go:798 +0x7a
k8s.io/client-go/util/workqueue.ParallelizeUntil.func1()
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/client-go/util/workqueue/parallelizer.go:90 +0x106
created by k8s.io/client-go/util/workqueue.ParallelizeUntil
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/client-go/util/workqueue/parallelizer.go:76 +0x1d7
I0701 08:18:11.056561  802594 event.go:294] "Event occurred" object="ingress-nginx/ingress-nginx-controller" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="EnsuringLoadBalancer" message="Ensuring load balancer"
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x153dbe4]

goroutine 347 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0006c8d20?})
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:56 +0xd8
panic({0x1ac2180, 0x2efded0})
	/home/phil/opt/go/1.18/src/runtime/panic.go:838 +0x207
github.com/exoscale/exoscale-cloud-controller-manager/exoscale.(*loadBalancer).updateLoadBalancer(0xc00034e990, {0x20668f8, 0xc0000520f8}, 0xc000678a01?)
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/exoscale/loadbalancer.go:246 +0x84
github.com/exoscale/exoscale-cloud-controller-manager/exoscale.(*loadBalancer).UpdateLoadBalancer(0xc0006c8c60?, {0x20668f8?, 0xc0000520f8?}, {0x2f2b7e0?, 0xc000819cd0?}, 0x0?, {0x0?, 0x0?, 0x7fba36349f40?})
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/exoscale/loadbalancer.go:186 +0x26
k8s.io/cloud-provider/controllers/service.(*Controller).lockedUpdateLoadBalancerHosts(0xc00062e0e0, 0xc0005444b0, {0xc00041bee0?, 0x2, 0x2})
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/cloud-provider/controllers/service/controller.go:824 +0x2fa
k8s.io/cloud-provider/controllers/service.(*Controller).nodeSyncService(0xc00062e0e0, 0xc0005444b0)
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/cloud-provider/controllers/service/controller.go:780 +0x259
k8s.io/cloud-provider/controllers/service.(*Controller).updateLoadBalancerHosts.func1(0x0)
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/cloud-provider/controllers/service/controller.go:798 +0x7a
k8s.io/client-go/util/workqueue.ParallelizeUntil.func1()
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/client-go/util/workqueue/parallelizer.go:90 +0x106
created by k8s.io/client-go/util/workqueue.ParallelizeUntil
	/home/phil/git/github.com/exoscale/exoscale-cloud-controller-manager/vendor/k8s.io/client-go/util/workqueue/parallelizer.go:76 +0x1d7
exit status 2
```