### PR TITLE
test: some more guidance and verbosity

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ There is two possible test environments:
 
 Simply execute either `./run-kubeadm-tests.sh` or `./run-sks-tests.sh`.
 
-**Everything** (Terraform, CCM launch, tests, etc.) will be automatically be handled for you.
+**Everything** (Terraform, CCM launch, tests, etc.) will be automatically handled for you.
 
 Once done and confident no resources linger behind, you may run `./clean-up.sh` (recommended before
 running another test).

--- a/test/README.md
+++ b/test/README.md
@@ -12,6 +12,15 @@ There is two possible test environments:
 - `terraform-kubeadm`: An "unmanaged" Kubernetes cluster, provisioned using kubeadm on top of Ubuntu instances.
 - `terraform-sks`: A managed SKS environment, deployed without the default/integrated Cloud Controller Manager instance.
 
+## Run the integration/acceptance tests
+
+Simply execute either `./run-kubeadm-tests.sh` or `./run-sks-tests.sh`.
+
+**Everything** (Terraform, CCM launch, tests, etc.) will be automatically be handled for you.
+
+Once done and confident no resources linger behind, you may run `./clean-up.sh` (recommended before
+running another test).
+
 ## Provisioning the development infrastructure
 
 You will need an Exoscale API key and secret. You can provide them as environment variables:

--- a/test/clean-up.sh
+++ b/test/clean-up.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+cd "$(dirname "$(realpath -e "${0}")")" || exit
+rm -v \
+  api-creds* \
+  *.log \
+  terraform-*/.env \
+  terraform-*/*.kubeconfig \
+  terraform-*/*.log \
+  terraform-*/*.pid \
+  terraform-*/*.tfstate*
+
+unset KUBECONFIG
+unset CCM_KUBECONFIG
+unset EXOSCALE_ZONE
+unset EXOSCALE_SKS_AGENT_RUNNERS
+unset EXOSCALE_API_CREDENTIALS_FILE
+
+unalias approve-csr
+unalias go-run-ccm

--- a/test/clean-up.sh
+++ b/test/clean-up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$(realpath -e "${0}")")" || exit
 rm -v \
   api-creds* \

--- a/test/lib/ccm-helpers.bash
+++ b/test/lib/ccm-helpers.bash
@@ -4,14 +4,14 @@ PID_FILE="terraform-${TARGET_CLUSTER}/ccm.pid"
 
 exoscale_ccm_start() {
 	if [ -f "$PID_FILE" ]; then
-		echo "CCM is already running (PID file is present: $PID_FILE)"
+		echo "!!! WARNING: CCM appears to be already running (PID file is present: $PID_FILE)"
 		exit 1
 	fi
 
-	echo " > Exoscale-CCM: Building initial environment"
+	echo "### Exoscale-CCM: Building initial environment"
 	. "terraform-${TARGET_CLUSTER}/.env"
-	
-	echo " > Exoscale-CCM: Starting"
+
+	echo "### Exoscale-CCM: Starting"
 	go run ../cmd/exoscale-cloud-controller-manager/main.go \
 		--kubeconfig="$CCM_KUBECONFIG" \
 		--authentication-kubeconfig="$CCM_KUBECONFIG" \
@@ -22,16 +22,16 @@ exoscale_ccm_start() {
 		--v=3 > ccm.log 2>&1 &
 
 	CCM_PID=$!
-	echo " > Exoscale-CCM: Started (PID=$CCM_PID)"
+	echo "### Exoscale-CCM: Started (PID=$CCM_PID)"
 	echo "$CCM_PID" > "$PID_FILE"
 }
 
 exoscale_ccm_kill() {
 	if [ -f "$PID_FILE" ]; then
 		CCM_PID="$(cat "$PID_FILE")"
-		echo " > Exoscale-CCM: Killing (PID=$CCM_PID)"
+		echo "### Exoscale-CCM: Killing (PID=$CCM_PID)"
 		pkill -P "$CCM_PID"
-		echo " > Exoscale-CCM: Killed"
+		echo "### Exoscale-CCM: Killed"
 		rm "$PID_FILE"
 	fi
 }

--- a/test/lib/ccm-helpers.bash
+++ b/test/lib/ccm-helpers.bash
@@ -3,35 +3,35 @@
 PID_FILE="terraform-${TARGET_CLUSTER}/ccm.pid"
 
 exoscale_ccm_start() {
-	if [ -f "$PID_FILE" ]; then
-		echo "!!! WARNING: CCM appears to be already running (PID file is present: $PID_FILE)"
-		exit 1
-	fi
+  if [ -f "$PID_FILE" ]; then
+    echo "!!! WARNING: CCM appears to be already running (PID file is present: $PID_FILE)"
+    exit 1
+  fi
 
-	echo "### Exoscale-CCM: Building initial environment"
-	. "terraform-${TARGET_CLUSTER}/.env"
+  echo "### Exoscale-CCM: Building initial environment"
+  . "terraform-${TARGET_CLUSTER}/.env"
 
-	echo "### Exoscale-CCM: Starting"
-	go run ../cmd/exoscale-cloud-controller-manager/main.go \
-		--kubeconfig="$CCM_KUBECONFIG" \
-		--authentication-kubeconfig="$CCM_KUBECONFIG" \
-		--authorization-kubeconfig="$CCM_KUBECONFIG" \
-		--cloud-config=cloud-config.conf \
-		--leader-elect=true \
-		--allow-untagged-cloud  \
-		--v=3 > ccm.log 2>&1 &
+  echo "### Exoscale-CCM: Starting"
+  go run ../cmd/exoscale-cloud-controller-manager/main.go \
+    --kubeconfig="$CCM_KUBECONFIG" \
+    --authentication-kubeconfig="$CCM_KUBECONFIG" \
+    --authorization-kubeconfig="$CCM_KUBECONFIG" \
+    --cloud-config=cloud-config.conf \
+    --leader-elect=true \
+    --allow-untagged-cloud  \
+    --v=3 > ccm.log 2>&1 &
 
-	CCM_PID=$!
-	echo "### Exoscale-CCM: Started (PID=$CCM_PID)"
-	echo "$CCM_PID" > "$PID_FILE"
+  CCM_PID=$!
+  echo "### Exoscale-CCM: Started (PID=$CCM_PID)"
+  echo "$CCM_PID" > "$PID_FILE"
 }
 
 exoscale_ccm_kill() {
-	if [ -f "$PID_FILE" ]; then
-		CCM_PID="$(cat "$PID_FILE")"
-		echo "### Exoscale-CCM: Killing (PID=$CCM_PID)"
-		pkill -P "$CCM_PID"
-		echo "### Exoscale-CCM: Killed"
-		rm "$PID_FILE"
-	fi
+  if [ -f "$PID_FILE" ]; then
+    CCM_PID="$(cat "$PID_FILE")"
+    echo "### Exoscale-CCM: Killing (PID=$CCM_PID)"
+    pkill -P "$CCM_PID"
+    echo "### Exoscale-CCM: Killed"
+    rm "$PID_FILE"
+  fi
 }

--- a/test/lib/test-setup.bash
+++ b/test/lib/test-setup.bash
@@ -14,10 +14,10 @@ terraform_create(){
 
 	cd "terraform-${TARGET_CLUSTER}" || exit
 	echo "### Initializing Terraform (plugins and providers)"
-  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-init.log')"
+	echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-init.log')"
 	terraform init -upgrade > terraform-init.log
 	echo "### Terraforming the test infrastructure"
-  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-apply.log')"
+	echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-apply.log')"
 	terraform apply -auto-approve > terraform-create.log
 	cd - > /dev/null || exit
 }
@@ -27,7 +27,7 @@ terraform_destroy() {
 
 	cd "terraform-${TARGET_CLUSTER}" || exit
 	echo "### Destroying Terraformed test infrastructure"
-  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-destroy.log')"
+	echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-destroy.log')"
 	terraform destroy -auto-approve > terraform-destroy.log
 	cd - > /dev/null || exit
 }

--- a/test/lib/test-setup.bash
+++ b/test/lib/test-setup.bash
@@ -1,17 +1,23 @@
 #!/bin/bash
 
 if [ -z "$EXOSCALE_API_KEY" ]; then
-  echo 'ERROR: Missing EXOSCALE_API_KEY environment variable'
+  echo '!!! ERROR: Missing EXOSCALE_API_KEY environment variable'
   exit
 fi
 if [ -z "$EXOSCALE_API_SECRET" ]; then
-  echo 'ERROR: Missing EXOSCALE_API_SECRET environment variable'
+  echo '!!! ERROR: Missing EXOSCALE_API_SECRET environment variable'
   exit
 fi
 
 terraform_create(){
 	echo "### Creating TEST environment ($TARGET_CLUSTER)"
+
 	cd "terraform-${TARGET_CLUSTER}" || exit
+	echo "### Initializing Terraform (plugins and providers)"
+  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-init.log')"
+	terraform init -upgrade > terraform-init.log
+	echo "### Terraforming the test infrastructure"
+  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-apply.log')"
 	terraform apply -auto-approve > terraform-create.log
 	cd - > /dev/null || exit
 }
@@ -20,6 +26,8 @@ terraform_destroy() {
 	echo "### Tearing down TEST environment ($TARGET_CLUSTER)"
 
 	cd "terraform-${TARGET_CLUSTER}" || exit
+	echo "### Destroying Terraformed test infrastructure"
+  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-destroy.log')"
 	terraform destroy -auto-approve > terraform-destroy.log
 	cd - > /dev/null || exit
 }

--- a/test/lib/test-setup.bash
+++ b/test/lib/test-setup.bash
@@ -10,31 +10,31 @@ if [ -z "$EXOSCALE_API_SECRET" ]; then
 fi
 
 terraform_create(){
-	echo "### Creating TEST environment ($TARGET_CLUSTER)"
+  echo "### Creating TEST environment ($TARGET_CLUSTER)"
 
-	cd "terraform-${TARGET_CLUSTER}" || exit
-	echo "### Initializing Terraform (plugins and providers)"
-	echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-init.log')"
-	terraform init -upgrade > terraform-init.log
-	echo "### Terraforming the test infrastructure"
-	echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-apply.log')"
-	terraform apply -auto-approve > terraform-create.log
-	cd - > /dev/null || exit
+  cd "terraform-${TARGET_CLUSTER}" || exit
+  echo "### Initializing Terraform (plugins and providers)"
+  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-init.log')"
+  terraform init -upgrade > terraform-init.log
+  echo "### Terraforming the test infrastructure"
+  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-apply.log')"
+  terraform apply -auto-approve > terraform-create.log
+  cd - > /dev/null || exit
 }
 
 terraform_destroy() {
-	echo "### Tearing down TEST environment ($TARGET_CLUSTER)"
+  echo "### Tearing down TEST environment ($TARGET_CLUSTER)"
 
-	cd "terraform-${TARGET_CLUSTER}" || exit
-	echo "### Destroying Terraformed test infrastructure"
-	echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-destroy.log')"
-	terraform destroy -auto-approve > terraform-destroy.log
-	cd - > /dev/null || exit
+  cd "terraform-${TARGET_CLUSTER}" || exit
+  echo "### Destroying Terraformed test infrastructure"
+  echo "  # (see 'terraform-${TARGET_CLUSTER}/terraform-destroy.log')"
+  terraform destroy -auto-approve > terraform-destroy.log
+  cd - > /dev/null || exit
 }
 
 clean() {
-	./ccm-kill
-	terraform_destroy
+  ./ccm-kill
+  terraform_destroy
 }
 
 trap clean EXIT

--- a/test/test-csr-validation.bash
+++ b/test/test-csr-validation.bash
@@ -15,8 +15,8 @@ cd - > /dev/null
 _until_success "test \$(kubectl get nodes --no-headers -l '!node-role.kubernetes.io/control-plane' 2> /dev/null | grep '^test-\S*-pool-' | wc -l) -ge 2"
 
 if [ "$TARGET_CLUSTER" != "sks" ]; then
-	echo "### (external node)"
-	_until_success "test \$(kubectl get nodes --no-headers -l '!node-role.kubernetes.io/control-plane' 2> /dev/null | grep '^test-\S*-external\s' | wc -l) -ge 1"
+  echo "### (external node)"
+  _until_success "test \$(kubectl get nodes --no-headers -l '!node-role.kubernetes.io/control-plane' 2> /dev/null | grep '^test-\S*-external\s' | wc -l) -ge 1"
 fi
 
 echo "### Checking that the Node CSR got approved ..."
@@ -24,8 +24,8 @@ echo "### Checking that the Node CSR got approved ..."
 _until_success "test \$(kubectl get csr --no-headers | grep '\ssystem:node:test-\S*-pool-\S.*\sApproved' 2> /dev/null | wc -l) -ge 2"
 
 if [ "$TARGET_CLUSTER" != "sks" ]; then
-	echo "### (external node)"
-	_until_success "test \$(kubectl get csr --no-headers | grep '\ssystem:node:test-\S*-external\s.*\sApproved' 2> /dev/null | wc -l) -ge 1"
+  echo "### (external node)"
+  _until_success "test \$(kubectl get csr --no-headers | grep '\ssystem:node:test-\S*-external\s.*\sApproved' 2> /dev/null | wc -l) -ge 1"
 fi
 
 echo "<<< PASS"


### PR DESCRIPTION
```
$ ./run-kubeadm-tests.bash 
### Creating TEST environment (kubeadm)
### Initializing Terraform (plugins and providers)
  # (see 'terraform-kubeadm/terraform-init.log')
### Terraforming the test infrastructure
  # (see 'terraform-kubeadm/terraform-apply.log')
### Exoscale-CCM: Building initial environment
### Exoscale-CCM: Starting
### Exoscale-CCM: Started (PID=443931)
>>> TESTING API CREDENTIALS FILE RELOADING
### Checking initial API credentials ...
### Refreshing API credentials ...
<<< PASS
>>> TESTING SKS AGENT NODE CSR VALIDATION
### Adding a Node to the cluster ...
### (external node)
### Checking that the Node CSR got approved ...
### (external node)
<<< PASS
>>> TESTING CCM-MANAGED KUBERNETES NODE LABELS
### Checking instance pool node labels ...
### Checking external node labels ...
<<< PASS
>>> TESTING CCM-MANAGED NLB INSTANCE
### Deploying cluster ingress controller ...
### Deploying test application ...
### Checking end-to-end requests ...
### Checking ingress HTTP NLB service properties ...
### Checking ingress HTTPS NLB service properties ...
### Updating ingress NLB services ...
### Destroying test application ...
### Deleting ingress NLB ...
<<< PASS
>>> TESTING CCM WITH EXTERNAL NLB INSTANCE
### Deploying Service ...
### Checking end-to-end requests ...
### Delete Service and keep external NLB instance ...
<<< PASS
>>> TESTING CCM-MANAGED NODE EXPUNGING
### Removing node-pool from the cluster ...
<<< PASS
### Exoscale-CCM: Killing (PID=443931)
### Exoscale-CCM: Killed
### Tearing down TEST environment (kubeadm)
### Destroying Terraformed test infrastructure
  # (see 'terraform-kubeadm/terraform-destroy.log')
@ 2022-11-08 17:31:02 +0100

$ ./clean-up.sh 
removed 'api-creds'
removed 'api-creds.init'
removed 'api-creds.new'
removed 'ccm.log'
rm: cannot remove 'terraform-*/.env': No such file or directory
rm: cannot remove 'terraform-*/*.kubeconfig': No such file or directory
removed 'terraform-kubeadm/terraform-apply.log'
removed 'terraform-kubeadm/terraform-destroy.log'
removed 'terraform-kubeadm/terraform-init.log'
removed 'terraform-kubeadm/test-csr-validation-terraform.log'
removed 'terraform-kubeadm/test-node-expunge-terraform.log'
rm: cannot remove 'terraform-*/*.pid': No such file or directory
removed 'terraform-kubeadm/terraform.tfstate'
removed 'terraform-kubeadm/terraform.tfstate.backup'
./clean-up.sh: line 18: unalias: approve-csr: not found
./clean-up.sh: line 19: unalias: go-run-ccm: not found
@ 2022-11-08 17:31:54 +0100
```