### PR TITLE
Fix instance-type label

### DIFF
--- a/exoscale/client_test.go
+++ b/exoscale/client_test.go
@@ -85,6 +85,6 @@ func (ts *exoscaleCCMTestSuite) Test_refreshableExoscaleClient_watchCredentialsF
 
 	client.RLock()
 	defer client.RUnlock()
-	ts.Require().Equal(client.apiCredentials, testAPICredentials)
+	ts.Require().Equal(testAPICredentials, client.apiCredentials)
 	ts.Require().NotNil(client.exo)
 }

--- a/exoscale/instances.go
+++ b/exoscale/instances.go
@@ -15,7 +15,9 @@ import (
 	cloudproviderapi "k8s.io/cloud-provider/api"
 )
 
-var labelInvalidCharsRegex = regexp.MustCompile(`([^A-Za-z0-9][^-A-Za-z0-9_.]*)?[^A-Za-z0-9]`)
+// Label value must be '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
+// Invalid characters will be removed
+var labelInvalidCharsRegex = regexp.MustCompile(`^[^A-Za-z0-9]|[^A-Za-z0-9]$|([^-A-Za-z0-9_.])`)
 
 type instances struct {
 	p   *cloudProvider
@@ -210,7 +212,7 @@ func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 		return "", err
 	}
 
-	return labelInvalidCharsRegex.ReplaceAllString(*instanceType.Size, ""), nil
+	return labelInvalidCharsRegex.ReplaceAllString(getInstanceTypeName(*instanceType.Family, *instanceType.Size), ""), nil
 }
 
 // AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
@@ -311,4 +313,9 @@ func (c *refreshableExoscaleClient) ListInstances(
 		zone,
 		opts...,
 	)
+}
+
+// Instance Type name is <family>.<size>
+func getInstanceTypeName(family string, size string) string {
+	return family + "." + size
 }

--- a/exoscale/instances_test.go
+++ b/exoscale/instances_test.go
@@ -1,6 +1,7 @@
 package exoscale
 
 import (
+	"fmt"
 	"net"
 
 	egoscale "github.com/exoscale/egoscale/v2"
@@ -10,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
+
 	"k8s.io/utils/pointer"
 )
 
@@ -170,7 +172,7 @@ func (ts *exoscaleCCMTestSuite) TestInstanceID() {
 
 	actual, err := ts.p.instances.InstanceID(ts.p.ctx, types.NodeName(testInstanceName))
 	ts.Require().NoError(err)
-	ts.Require().Equal(actual, testInstanceID)
+	ts.Require().Equal(testInstanceID, actual)
 }
 
 func (ts *exoscaleCCMTestSuite) TestInstanceType() {
@@ -214,9 +216,10 @@ func (ts *exoscaleCCMTestSuite) TestInstanceType() {
 		},
 	})
 
+	testInstanceTypeName := getInstanceTypeName(testInstanceTypeFamily, testInstanceTypeSize)
 	actual, err := ts.p.instances.InstanceType(ts.p.ctx, types.NodeName(testInstanceName))
 	ts.Require().NoError(err)
-	ts.Require().Equal(actual, testInstanceTypeSize)
+	ts.Require().Equal(testInstanceTypeName, actual)
 }
 
 func (ts *exoscaleCCMTestSuite) TestInstanceTypeByProviderID() {
@@ -259,10 +262,11 @@ func (ts *exoscaleCCMTestSuite) TestInstanceTypeByProviderID() {
 			},
 		},
 	})
-
+	testInstanceTypeName := getInstanceTypeName(testInstanceTypeFamily, testInstanceTypeSize)
+	fmt.Println(testInstanceTypeName)
 	actual, err := ts.p.instances.InstanceTypeByProviderID(ts.p.ctx, providerPrefix+testInstanceID)
 	ts.Require().NoError(err)
-	ts.Require().Equal(actual, testInstanceTypeSize)
+	ts.Require().Equal(testInstanceTypeName, actual)
 }
 
 func (ts *exoscaleCCMTestSuite) AddSSHKeyToAllInstances() {
@@ -287,7 +291,7 @@ func (ts *exoscaleCCMTestSuite) TestCurrentNodeName() {
 
 	actual, err := ts.p.instances.CurrentNodeName(ts.p.ctx, testInstanceName)
 	ts.Require().NoError(err)
-	ts.Require().Equal(actual, types.NodeName(testInstanceName))
+	ts.Require().Equal(types.NodeName(testInstanceName), actual)
 }
 
 func (ts *exoscaleCCMTestSuite) TestInstanceExistsByProviderID() {
@@ -396,19 +400,19 @@ func (ts *exoscaleCCMTestSuite) TestNodeAddressesByProviderID_overrideExternal()
 func (ts *exoscaleCCMTestSuite) TestInstanceID_overrideExternal() {
 	actual, err := ts.p.instances.InstanceID(ts.p.ctx, types.NodeName(testInstanceOverrideRegexpNodeName))
 	ts.Require().NoError(err)
-	ts.Require().Equal(actual, testInstanceOverrideRegexpInstanceID)
+	ts.Require().Equal(testInstanceOverrideRegexpInstanceID, actual)
 }
 
 func (ts *exoscaleCCMTestSuite) TestInstanceType_overrideExternal() {
 	actual, err := ts.p.instances.InstanceType(ts.p.ctx, types.NodeName(testInstanceOverrideRegexpNodeName))
 	ts.Require().NoError(err)
-	ts.Require().Equal(actual, testInstanceOverrideExternalType)
+	ts.Require().Equal(testInstanceOverrideExternalType, actual)
 }
 
 func (ts *exoscaleCCMTestSuite) TestInstanceTypeByProviderID_overrideExternal() {
 	actual, err := ts.p.instances.InstanceTypeByProviderID(ts.p.ctx, testInstanceOverrideRegexpProviderID)
 	ts.Require().NoError(err)
-	ts.Require().Equal(actual, testInstanceOverrideExternalType)
+	ts.Require().Equal(testInstanceOverrideExternalType, actual)
 }
 
 func (ts *exoscaleCCMTestSuite) TestInstanceExistsByProviderID_overrideExternal() {

--- a/exoscale/loadbalancer_test.go
+++ b/exoscale/loadbalancer_test.go
@@ -39,7 +39,7 @@ var (
 
 func (ts *exoscaleCCMTestSuite) Test_newLoadBalancer() {
 	actual := newLoadBalancer(ts.p, &testConfig_typical.LoadBalancer)
-	ts.Require().Equal(actual, &loadBalancer{p: ts.p, cfg: &testConfig_typical.LoadBalancer})
+	ts.Require().Equal(&loadBalancer{p: ts.p, cfg: &testConfig_typical.LoadBalancer}, actual)
 }
 
 func (ts *exoscaleCCMTestSuite) Test_loadBalancer_isExternal() {
@@ -457,7 +457,7 @@ func (ts *exoscaleCCMTestSuite) Test_loadBalancer_GetLoadBalancer() {
 			},
 		},
 	})
-	ts.Require().Equal(actualStatus, expectedStatus)
+	ts.Require().Equal(expectedStatus, actualStatus)
 	ts.Require().True(exists)
 	ts.Require().NoError(err)
 
@@ -547,7 +547,7 @@ func (ts *exoscaleCCMTestSuite) Test_loadBalancer_fetchLoadBalancer() {
 			},
 		},
 	})
-	ts.Require().Equal(actual, expected)
+	ts.Require().Equal(expected, actual)
 	ts.Require().NoError(err)
 
 	// Non-existent NLB


### PR DESCRIPTION
- Instance Type label should be: `<family>.<size>` (only size was present in the label since apiv2 migration)
- Fix regex ( `.`, `-` and `_` were always replaced)
- Fix some tests (expected and actual were inverted) 