### PR TITLE
test(acc): test_kubeconfig_external_node does not apply to SKS test type

### DIFF
--- a/test/tests_2_nodes/test_202_nodes_files.py
+++ b/test/tests_2_nodes/test_202_nodes_files.py
@@ -2,8 +2,14 @@ import os.path
 
 import pytest
 
+from helpers import TEST_CCM_TYPE
+
 
 @pytest.mark.nodes
+@pytest.mark.skipif(
+    TEST_CCM_TYPE not in ["kubeadm"],
+    reason="This test may only be performed for 'kubeadm' type (<-> external node kubeconfig/username)",
+)
 def test_kubeconfig_external_node(tf_nodes):
     path = tf_nodes["external_node_kubeconfig"]
     assert "/output/" in path


### PR DESCRIPTION
FIX for `tests_2_nodes/test_202_nodes_files.py::test_kubeconfig_external_node FAILED` when `TEST_CCM_TYPE='sks'`