### PR TITLE
SKS: Fix CSR approval for instance name with uppercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* Fix CSR approval for instance name with uppercase (#68)
+
 ## 0.14.0
 
 * Upgrade Kubernetes SDK to 1.28.1, egoscale to 0.100.3

--- a/exoscale/sks_agent_runner_node_csr_validation.go
+++ b/exoscale/sks_agent_runner_node_csr_validation.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	k8scertv1 "k8s.io/api/certificates/v1"
@@ -114,7 +115,7 @@ func (r *sksAgentRunnerNodeCSRValidation) run(ctx context.Context) {
 
 				csrOK := false
 				for _, instance := range instances {
-					if *instance.Name == parsedCSR.DNSNames[0] {
+					if strings.ToLower(*instance.Name) == parsedCSR.DNSNames[0] {
 						var nodeAddrs []string
 
 						if instance.PublicIPAddress != nil {

--- a/exoscale/sks_agent_runner_node_csr_validation_test.go
+++ b/exoscale/sks_agent_runner_node_csr_validation_test.go
@@ -28,6 +28,9 @@ import (
 )
 
 func (ts *exoscaleCCMTestSuite) generateK8sCSR(nodeName string, nodeIPAddresses []string) []byte {
+
+	// k8s node name are lowercase only
+	k8sNodeName := strings.ToLower(nodeName)
 	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	ts.Require().NoError(err, "failed to generate RSA private key")
 
@@ -42,9 +45,9 @@ func (ts *exoscaleCCMTestSuite) generateK8sCSR(nodeName string, nodeIPAddresses 
 			SignatureAlgorithm: x509.SHA512WithRSA,
 			Subject: pkix.Name{
 				Organization: []string{"system:nodes"},
-				CommonName:   "system:nodes:" + nodeName,
+				CommonName:   "system:nodes:" + k8sNodeName,
 			},
-			DNSNames:    []string{nodeName},
+			DNSNames:    []string{k8sNodeName},
 			IPAddresses: ipAddresses,
 		},
 		privateKey,

--- a/test/show
+++ b/test/show
@@ -3,6 +3,7 @@ SCRIPT="${0##*/}"
 
 ## Defaults
 : "${EXOSCALE_ZONE:=ch-gva-2}"
+: "${KUBECTL:=kubectl}"
 
 ## Usage
 __USAGE() {
@@ -64,43 +65,43 @@ case "${MY_scope}" in
     case "${MY_item}" in
       'nodes')
         if [ "${MY_format}" == 'json' ]; then
-          kubectl -o json get nodes "${@}" \
+          ${KUBECTL} -o json get nodes "${@}" \
             | jq '.items[]|.metadata.name, (.status.conditions[]|select(.type=="Ready")).status, .metadata.labels, .status.addresses'
         else
-          kubectl -o wide get nodes "${@}" \
+          ${KUBECTL} -o wide get nodes "${@}" \
             | grep -E '^(NAME|test-ccm)'
         fi
       ;;
       'csrs')
         if [ "${MY_format}" == 'json' ]; then
-          kubectl -o json get csr "${@}" \
+          ${KUBECTL} -o json get csr "${@}" \
             | jq '.items[]|select(.spec.username|test("test-ccm"))|.metadata.name, .spec.username, (.status.conditions[]?|select(.type=="Approved")).status'
         else
-          kubectl -o wide get csr "${@}" \
+          ${KUBECTL} -o wide get csr "${@}" \
             | grep -E '(^NAME|test-ccm)'
         fi
         ;;
       'pods')
         if [ "${MY_format}" == 'json' ]; then
-          kubectl -o json get pods "${@}" \
+          ${KUBECTL} -o json get pods "${@}" \
             | jq '.items[]|select(.spec.nodeName|test("^test-ccm"))'
         else
-          kubectl -o wide get pods "${@}" \
+          ${KUBECTL} -o wide get pods "${@}" \
             | grep -E '(^NAME|test-ccm)'
         fi
         ;;
       'services')
         if [ "${MY_format}" == 'json' ]; then
-          kubectl -o json get services "${@}" \
+          ${KUBECTL} -o json get services "${@}" \
             | jq '.items[]|select(.spec.type=="LoadBalancer")|.metadata.namespace+":"+.metadata.name, .spec.ports, .status'
         else
-          kubectl -o wide get services "${@}" \
+          ${KUBECTL} -o wide get services "${@}" \
             | grep -E '(^NAME|LoadBalancer)'
         fi
       ;;
       'events')
         if [ "${MY_format}" == 'json' ]; then
-          kubectl -o json get events "${@}" \
+          ${KUBECTL} -o json get events "${@}" \
             | jq
         else
           kubectl \

--- a/test/terraform/sks/nodes/main.tf
+++ b/test/terraform/sks/nodes/main.tf
@@ -16,7 +16,7 @@ resource "exoscale_sks_nodepool" "nodepool" {
 
   cluster_id      = var.test_cluster_id
   instance_type   = "standard.small"
-  instance_prefix = "${local.test_name}-pool"
+  instance_prefix = "${local.test_name}-Pool"
   size            = var.test_nodes_pool_size
 
   anti_affinity_group_ids = [exoscale_anti_affinity_group.nodes_aag.id]


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

- K8s node name is always lowercase, DNSNames in CSR too, not Instance Name, CCM could not find an Instance when name contains uppercase 
- updates tests 

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->

```
 $ ./run  -t sks
INFO[run]: Running test type 'sks'
================================================================================ test session starts =================================================================================
platform linux -- Python 3.11.3, pytest-7.4.0, pluggy-1.3.0
rootdir: /home/jessica/git/exoscale/exoscale-cloud-controller-manager/test
configfile: pytest.ini
collected 69 items / 1 deselected / 68 selected

tests_0_environment/test_001_environment.py .....                                                                                                                              [  7%]
tests_1_control_plane/test_101_control_plane.py .                                                                                                                              [  8%]
tests_1_control_plane/test_102_control_plane_files.py ......                                                                                                                   [ 17%]
tests_1_control_plane/test_103_control_plane_start.py ..                                                                                                                       [ 20%]
tests_2_nodes/test_201_nodes.py .                                                                                                                                              [ 22%]
tests_2_nodes/test_202_nodes_files.py s.                                                                                                                                       [ 25%]
tests_3_ccm/test_300_init.py .                                                                                                                                                 [ 26%]
tests_3_ccm/test_301_k8s_state.py ..                                                                                                                                           [ 29%]
tests_3_ccm/test_302_ccm_start.py .....                                                                                                                                        [ 36%]
tests_3_ccm/test_303_ccm_node_csr_validation.py .                                                                                                                              [ 38%]
tests_3_ccm/test_304_ccm_node_csr_invalid.py ss                                                                                                                                [ 41%]
tests_3_ccm/test_305_ccm_nodes.py x                                                                                                                                            [ 42%]
tests_3_ccm/test_306_ccm_api_credentials_update.py ..                                                                                                                          [ 45%]
tests_3_ccm/test_307_k8s_nodes.py x.x                                                                                                                                          [ 50%]
tests_4_nlb/test_400_init.py ..                                                                                                                                                [ 52%]
tests_4_nlb/test_401_nlb_hello_external.py .....                                                                                                                               [ 60%]
tests_4_nlb/test_402_nlb_ingress_nginx.py .......                                                                                                                              [ 70%]
tests_4_nlb/test_403_nlb_hello_ingress.py ..                                                                                                                                   [ 73%]
tests_5_nodes_pool_resize/test_500_init.py ..                                                                                                                                  [ 76%]
tests_5_nodes_pool_resize/test_501_k8s_state.py ...                                                                                                                            [ 80%]
tests_5_nodes_pool_resize/test_502_ccm_nodes_deletion.py s                                                                                                                     [ 82%]
tests_5_nodes_pool_resize/test_503_ccm_nodes_csr_validation.py .                                                                                                               [ 83%]
tests_5_nodes_pool_resize/test_504_k8s_nodes.py .                                                                                                                              [ 85%]
tests_5_nodes_pool_resize/test_505_nlb_hello.py ..                                                                                                                             [ 88%]
tests_5_nodes_pool_resize/test_501_k8s_state.py ...                                                                                                                            [ 92%]
tests_5_nodes_pool_resize/test_502_ccm_nodes_deletion.py X                                                                                                                     [ 94%]
tests_5_nodes_pool_resize/test_503_ccm_nodes_csr_validation.py s                                                                                                               [ 95%]
tests_5_nodes_pool_resize/test_504_k8s_nodes.py .                                                                                                                              [ 97%]
tests_5_nodes_pool_resize/test_505_nlb_hello.py ..                                                                                                                             [100%]

=================================================== 59 passed, 5 skipped, 1 deselected, 3 xfailed, 1 xpassed in 960.53s (0:16:00) ====================================================
```