### PR TITLE
Add missing definition for CI builds

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,0 +1,19 @@
+name: "Build"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - run: git submodule update --init --recursive go.mk
+      shell: bash
+    - uses: ./go.mk/.github/actions/setup
+
+    - uses: ./go.mk/.github/actions/pre-check
+
+    - run: make build
+      shell: bash
+
+    - run: make test-verbose
+      shell: bash


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

According to my [last release attempt](https://github.com/exoscale/exoscale-cloud-controller-manager/actions/runs/7708071292/job/21006421996), there is a missing file: `.github/actions/build/action.yaml`.

See also [this change](https://github.com/exoscale/exoscale-cloud-controller-manager/pull/73/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R20)

This prevents us from publishing new releases.

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->

Locally ran commands from the definition.