### PR TITLE
go.mk: provide alternative to submodule approach

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -6,7 +6,7 @@ runs:
       with:
         fetch-depth: 0
 
-    - run: git submodule update --init --recursive go.mk
+    - run: make go.mk
       shell: bash
     - uses: ./go.mk/.github/actions/setup
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
 
       - uses: ./go.mk/.github/actions/pre-check
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - name: Build
         run: make build
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: git submodule update --init --recursive go.mk
+      - run: make go.mk
       - uses: ./go.mk/.github/actions/setup
       - name: Build Docker image
         run: make docker

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/go.mk
 dist/
 bin/
 release/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+* go.mk: provide alternative to submodule approach #77 
 * automate releasing with GH Actions (#73)
 * Bump Kubernetes SDK to 1.29.0
 * CCM is now built with Go 1.21

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,32 @@
+GO_MK_REF := v1.0.0
+
+# make go.mk a dependency for all targets
+.EXTRA_PREREQS = go.mk
+
+ifndef MAKE_RESTARTS
+# This section will be processed the first time that make reads this file.
+
+# This causes make to re-read the Makefile and all included
+# makefiles after go.mk has been cloned.
+Makefile:
+	@touch Makefile
+endif
+
+.PHONY: go.mk
+.ONESHELL:
+go.mk:
+	@if [ ! -d "go.mk" ]; then
+		git clone https://github.com/exoscale/go.mk.git
+	fi
+	@cd go.mk
+	@if ! git show-ref --quiet --verify "refs/heads/${GO_MK_REF}"; then
+		git fetch
+	fi
+	@if ! git show-ref --quiet --verify "refs/tags/${GO_MK_REF}"; then
+		git fetch --tags
+	fi
+	git checkout --quiet ${GO_MK_REF}
+
 ## Project
 
 PACKAGE := github.com/exoscale/exoscale-cloud-controller-manager
@@ -11,7 +40,9 @@ EXTRA_ARGS := -parallel 3 -count=1 -failfast
 # Requires: https://github.com/exoscale/go.mk
 # - install: git submodule update --init --recursive go.mk
 # - update:  git submodule update --remote
+go.mk/init.mk:
 include go.mk/init.mk
+go.mk/public.mk:
 include go.mk/public.mk
 
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -2,6 +2,7 @@
 
 # Dependencies
 # (do not pull the entire Go build environment in)
+go.mk/version.mk:
 include go.mk/version.mk
 
 


### PR DESCRIPTION
## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

```shell
❯ make docker
Cloning into 'go.mk'...
remote: Enumerating objects: 311, done.
remote: Counting objects: 100% (197/197), done.
remote: Compressing objects: 100% (95/95), done.
remote: Total 311 (delta 132), reused 138 (delta 93), pack-reused 114
Receiving objects: 100% (311/311), 62.32 KiB | 657.00 KiB/s, done.
Resolving deltas: 100% (175/175), done.
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/home/sauterp/src/github.com/exoscale/exoscale-cloud-controller-manager/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
docker build --rm \
  -t exoscale/cloud-controller-manager \
  --build-arg VERSION="dev" \
  --build-arg VCS_REF="12676f7c" \
  --build-arg BUILD_DATE="2024-02-22T15:02:25Z" \
  .
docker tag exoscale/cloud-controller-manager:latest exoscale/cloud-controller-manager:dev
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  450.8MB
Step 1/15 : FROM golang:1.20-alpine as builder
 ---> e9f54d6722ab
Step 2/15 : RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
 ---> Using cache
 ---> fc87aa6c6d59
Step 3/15 : WORKDIR /go/src/github.com/exoscale/exoscale-cloud-controller-manager
 ---> Running in b973f935e4fc
Removing intermediate container b973f935e4fc
 ---> 651ad02bc337
Step 4/15 : COPY . .
 ---> 968ce02a9370
Step 5/15 : ARG VERSION
 ---> Running in 3a52e06962e3
Removing intermediate container 3a52e06962e3
 ---> e488fc993f65
Step 6/15 : RUN CGO_ENABLED=0     go build -mod vendor     -ldflags "-w -s -X github.com/exoscale/exoscale-cloud-controller-manager/exoscale.version=${VERSION}"     -o ./bin/exoscale-cloud-controller-manager     ./cmd/exoscale-cloud-controller-manager
 ---> Running in 66c096c48a29
Removing intermediate container 66c096c48a29
 ---> cb107f8a4dda
Step 7/15 : FROM busybox:1.32.0
 ---> 219ee5171f80
Step 8/15 : ARG VERSION
 ---> Using cache
 ---> 63552f3121e2
Step 9/15 : ARG VCS_REF
 ---> Using cache
 ---> 832b4b1b7eef
Step 10/15 : ARG BUILD_DATE
 ---> Using cache
 ---> c4fdeabe9a53
Step 11/15 : LABEL org.label-schema.build-date=${BUILD_DATE}       org.label-schema.vcs-ref=${VCS_REF}       org.label-schema.vcs-url="https://github.com/exoscale/exoscale-cloud-controller-manager"       org.label-schema.version=${VERSION}       org.label-schema.name="exoscale-cloud-controller-manager"       org.label-schema.vendor="Exoscale"       org.label-schema.description="Exoscale Cloud Controller Manager"       org.label-schema.schema-version="1.0"
 ---> Running in 5e96122f1493
Removing intermediate container 5e96122f1493
 ---> 1c5551e64f33
Step 12/15 : WORKDIR /
 ---> Running in 082acb049b08
Removing intermediate container 082acb049b08
 ---> 1d9faa36e42b
Step 13/15 : COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ---> 3deb5837f282
Step 14/15 : COPY --from=builder /go/src/github.com/exoscale/exoscale-cloud-controller-manager/bin/exoscale-cloud-controller-manager .
 ---> 6fac2ad55102
Step 15/15 : ENTRYPOINT ["/exoscale-cloud-controller-manager"]
 ---> Running in 0ea6a5099d59
Removing intermediate container 0ea6a5099d59
 ---> 0535d9c0b0c1
Successfully built 0535d9c0b0c1
Successfully tagged exoscale/cloud-controller-manager:latest
```
