### PR TITLE
ccm-command: print returned error before exiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* ccm-command: print returned error before exiting #81 
+
 ## 0.29.1
 
 ### Improvements

--- a/cmd/exoscale-cloud-controller-manager/main.go
+++ b/cmd/exoscale-cloud-controller-manager/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -52,7 +51,7 @@ func main() {
 	})
 
 	if err := command.Execute(); err != nil {
-		os.Exit(1) //nolint:gocritic
+		klog.Fatalf("cloud-controller-manger command failed: %s", err)
 	}
 }
 


### PR DESCRIPTION
# Description

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

