### PR TITLE
go.mk: lint with staticcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 * Update examples used in getting-started.md #82
+* go.mk: lint with staticcheck #83 
 
 ## 0.29.2
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_MK_REF := v1.0.0
+GO_MK_REF := v2.0.0
 
 # make go.mk a dependency for all targets
 .EXTRA_PREREQS = go.mk


### PR DESCRIPTION
# Description

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing
```shell
make lint
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/home/sauterp/src/github.com/exoscale/exoscale-cloud-controller-manager/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
remote: Enumerating objects: 21, done.        
remote: Counting objects: 100% (19/19), done.        
remote: Compressing objects: 100% (11/11), done.        
remote: Total 21 (delta 8), reused 13 (delta 7), pack-reused 2        
Unpacking objects: 100% (21/21), 8.45 KiB | 2.11 MiB/s, done.
From github.com:exoscale/go.mk
   3c2fe25..c320e5b  master     -> origin/master
 * [new tag]         v2.0.0     -> v2.0.0
 * [new tag]         v1.0.1     -> v1.0.1
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/home/sauterp/src/github.com/exoscale/exoscale-cloud-controller-manager/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
'/home/sauterp/bin/go' install honnef.co/go/tools/cmd/staticcheck@2023.1.7
'/home/sauterp/go/bin/staticcheck' \
   \
  ./...
```