### PR TITLE
chore(doc): add note about make for macOS users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+* chore(doc): add note about make for macos users
+
 ## 0.30.0
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-* chore(doc): add note about make for macos users
+* chore(doc): add note about make for macOS users
 
 ## 0.30.0
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,10 +11,10 @@ images][docker-hub] in your Kubernetes manifests.
 ### Compile from sources
 
 > [!IMPORTANT]
-> macOS users **must** install recent `make` binaries since the current version
+> macOS users **must** install recent `make` binary since the current version
 > shipping with developper tools is outdated.
 >
-> You can simply intall GNU make with homebrew via `brew install make`. Do not
+> You can simply install GNU make with homebrew via `brew install make`. Do not
 > forget to use `gmake` command instead or add the path
 > `$(brew --prefix make)/libexec/gnubin` to your `$PATH`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ images][docker-hub] in your Kubernetes manifests.
 
 ### Compile from sources
 
-> ![IMPORTANT]
+> [!IMPORTANT]
 > macOS users **must** install recent `make` binaries since the current version
 > shipping with developper tools is outdated.
 >

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,14 @@ images][docker-hub] in your Kubernetes manifests.
 
 ### Compile from sources
 
+> ![IMPORTANT]
+> macOS users **must** install recent `make` binaries since the current version
+> shipping with developper tools is outdated.
+>
+> You can simply intall GNU make with homebrew via `brew install make`. Do not
+> forget to use `gmake` command instead or add the path
+> `$(brew --prefix make)/libexec/gnubin` to your `$PATH`.
+
 If you wish to compile the Exoscale Cloud Controller Manager (CCM) from
 sources, run the following command at the root of the sources:
 


### PR DESCRIPTION
# Description

The `make` binary shipping with Apple toolbelt is outdated and must be updated.

## Checklist
(For exoscale contributors)

* [x] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

N/A
