### PR TITLE
fix(sc-105769): add unittests on instances.NodeAddressesByProviderID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ test/**/id_*
 test/**/nlb_service_*
 *.log
 *.pid
+
+# vscode
+__debug_bin*


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

instance.IPv6Enabled case was not covered nor instance.PrivateNetworkIDs

It's now solved

It's a prerequiside for sc-105769 which will change behavior of this function

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [x] Testing

## Testing

<!--
Describe the tests you did
-->
