### PR TITLE
Support UDP for LoadBalancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add UDP Support to LoadBalancer service
 * fix(instances): ensure internal IP is set when there is only public one
 
 ### Improvements

--- a/test/README.md
+++ b/test/README.md
@@ -71,6 +71,8 @@ Run the tests with minimal verbosity (for successful tests reporting in Pull-Req
 # Set your Exoscale (API) credentials
 export EXOSCALE_API_KEY='EXO...'
 export EXOSCALE_API_SECRET='...'
+# ch-gva-2 currently required
+export EXOSCALE_ZONE="ch-gva-2"
 
 # Run the tests
 pytest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -512,3 +512,37 @@ def nlb_hello_ingress(test, tf_control_plane, tf_nodes, nlb_ingress_nginx, logge
             ],
             kubeconfig=tf_control_plane["kubeconfig_admin"],
         )
+
+@pytest.fixture(scope="session")
+def nlb_udp_echo_external(test, tf_control_plane, tf_nodes, ccm, logger):
+    manifest = tf_nodes["manifest_udp_echo"]
+
+    # Apply the UDP Echo application manifest
+    logger.info("[K8s] Applying UDP Echo (external NLB) application manifest ...")
+    kubectl(
+        [
+            "apply",
+            f"--filename={manifest}",
+        ],
+        kubeconfig=tf_control_plane["kubeconfig_admin"],
+        pyexit=True,
+    )
+
+    # Yield the manifest for use in tests
+    yield manifest
+
+    # Teardown
+    if not os.getenv("TEST_CCM_NO_NLB_TEARDOWN"):
+        logger.info(
+            "[K8s] Deleting UDP Echo (external NLB) application manifest (this may take some time) ..."
+        )
+        kubectl(
+            [
+                "delete",
+                f"--filename={manifest}",
+            ],
+            kubeconfig=tf_control_plane["kubeconfig_admin"],
+        )
+    else:
+        logger.info("[K8s] Skipping teardown of UDP Echo manifest due to environment variable.")
+

--- a/test/resources/manifests/udp-echo.yaml
+++ b/test/resources/manifests/udp-echo.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: udp-echo
+  labels:
+    app: udp-echo
+    app.kubernetes.io/name: udp-echo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: udp-echo
+  template:
+    metadata:
+      labels:
+        app: udp-echo
+    spec:
+      containers:
+      - name: udp-echo
+        image: alpine
+        command: ["sh", "-c", "while true; do echo -n 'Echo' | nc -u -l -p 8080 -w 1; done"]
+        ports:
+        - containerPort: 8080
+          protocol: UDP
+      - name: tcp-healthcheck
+        image: k8s.gcr.io/echoserver:1.10
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: udp-echo-service
+  annotations:
+    service.beta.kubernetes.io/exoscale-loadbalancer-zone: "${exoscale_zone}"
+    service.beta.kubernetes.io/exoscale-loadbalancer-id: "${exoscale_nlb_id}"
+    service.beta.kubernetes.io/exoscale-loadbalancer-external: "true"
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-instancepool-id: "${exoscale_instance_pool_id}"
+    service.beta.kubernetes.io/exoscale-loadbalancer-service-healthcheck-port: "31621"
+spec:
+  type: LoadBalancer
+  ports:
+    - name: udpapplication
+      port: 8080                 # External UDP Port
+      protocol: UDP
+      targetPort: 8080           # ContainerPort
+    - name: udpapphealthcheck
+      port: 8080                 # Health check port (TCP)
+      targetPort: 8080           # ContainerPort for TCP health checks
+      nodePort: 31621            # Must match the annotation above
+      protocol: TCP
+  selector:
+    app: udp-echo

--- a/test/terraform/sks/control-plane/main.tf
+++ b/test/terraform/sks/control-plane/main.tf
@@ -14,6 +14,8 @@ resource "exoscale_security_group_rule" "cluster_sg_rule" {
     kubelet_logs           = { protocol = "TCP", port = 10250, cidr = "0.0.0.0/0" },
     kubelet_nodeports_ipv4 = { protocol = "TCP", port = "30000-32767", cidr = "0.0.0.0/0" }
     kubelet_nodeports_ipv6 = { protocol = "TCP", port = "30000-32767", cidr = "::/0" }
+    kubelet_nodeports_ipv4_udp = { protocol = "UDP", port = "30000-32767", cidr = "0.0.0.0/0" }
+    kubelet_nodeports_ipv6_udp = { protocol = "UDP", port = "30000-32767", cidr = "::/0" }
     # Calico
     # REF: https://projectcalico.docs.tigera.io/getting-started/kubernetes/requirements#network-requirements
     calico_typha = { protocol = "TCP", port = 5473, sg = exoscale_security_group.cluster_sg.id }

--- a/test/terraform/sks/nodes/files.tf
+++ b/test/terraform/sks/nodes/files.tf
@@ -13,6 +13,13 @@ resource "local_file" "app_manifest" {
       }
     }
     "hello-ingress" = {}
+    "udp-echo" = {
+      variables = {
+        exoscale_zone             = var.exoscale_zone
+        exoscale_nlb_id           = exoscale_nlb.external_nlb.id
+        exoscale_instance_pool_id = var.test_nodes_pool_size > 0 ? exoscale_sks_nodepool.nodepool[0].instance_pool_id : "n/a"
+      }
+    }
   }
 
   filename = abspath("${path.module}/output/manifests/${each.key}.yaml")

--- a/test/terraform/sks/nodes/outputs.tf
+++ b/test/terraform/sks/nodes/outputs.tf
@@ -60,3 +60,6 @@ output "manifest_hello_external" {
 output "manifest_hello_ingress" {
   value = local_file.app_manifest["hello-ingress"].filename
 }
+output "manifest_udp_echo" {
+  value = local_file.app_manifest["udp-echo"].filename
+}

--- a/test/tests_1_control_plane/test_103_control_plane_start.py
+++ b/test/tests_1_control_plane/test_103_control_plane_start.py
@@ -22,7 +22,7 @@ def test_k8s_version(test, tf_control_plane, logger):
         output["serverVersion"]["major"],
         output["serverVersion"]["minor"],
     )
-    assert version_major_minor in ["1.28", "1.29", "1.30"]
+    assert version_major_minor in ["1.28", "1.29", "1.30", "1.31"]
 
 
 @pytest.mark.control_plane

--- a/test/tests_4_nlb/test_404_nlb_echo_udp.py
+++ b/test/tests_4_nlb/test_404_nlb_echo_udp.py
@@ -1,0 +1,83 @@
+import json
+from time import sleep, time
+import socket
+
+import pytest
+
+from helpers import kubectl, exocli, ioMatch
+
+
+@pytest.mark.nlb
+def test_k8s_udp_echo_external(test, tf_control_plane, nlb_udp_echo_external, logger):
+    # Deployment
+    (iExit, sStdOut, sStdErr) = kubectl(
+        [
+            "--output=json",
+            "--namespace=default",
+            "wait",
+            "--timeout=600s",
+            "--for=condition=Available",
+            "deployment/udp-echo",
+        ],
+        kubeconfig=tf_control_plane["kubeconfig_admin"],
+    )
+    assert iExit == 0
+    manifest = json.loads(sStdOut)
+    logger.debug(
+        f"[K8s] Asserting UDP Echo (external NLB) application (Deployment) manifest:\n{manifest}"
+    )
+
+    assert manifest["kind"] == "Deployment"
+    assert manifest["metadata"]["labels"]["app.kubernetes.io/name"] == "udp-echo"
+
+
+@pytest.mark.nlb
+def test_udp_echo_service_creation(test, ccm, nlb_udp_echo_external, logger):
+    nlb_name = test["state"]["nlb"]["external"]["name"]
+    if nlb_name is None:
+        pytest.skip("Nodes NLB preliminary test has not run (or has failed)")
+    for port in [8080]:
+        (lines, match, unmatch) = ioMatch(
+            ccm,
+            matches=[
+                f"re:/NLB service {nlb_name}/(\\S+-{port}) created successfully \\(ID: ([^)]+)\\)/i"
+            ],
+            timeout=test["timeout"]["nlb"]["service"]["start"],
+            logger=logger,
+        )
+        assert lines > 0
+        assert unmatch is None
+        assert match is not None
+        service_name = match[1]
+        service_id = match[2]
+
+        # State (update)
+        test["state"]["nlb"]["external"]["services"][port] = {
+            "name": service_name,
+            "id": service_id,
+        }
+        logger.info(f"[CCM] Created NLB service: {service_name} (ID:{service_id})")
+
+
+@pytest.mark.nlb
+def test_udp_echo_external_response(test, tf_nodes, nlb_udp_echo_external, logger):
+    nlb_ipv4 = test["state"]["nlb"]["external"]["ipv4"]
+    if nlb_ipv4 is None:
+        pytest.skip("Nodes NLB preliminary test has not run (or has failed)")
+
+    udp_port = 8080
+    logger.debug(f"[NLB] Testing UDP Echo server on {nlb_ipv4}:{udp_port}")
+
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.settimeout(5.0)
+        try:
+            # Send data
+            message = "Hello UDP"
+            sock.sendto(message.encode(), (nlb_ipv4, udp_port))
+
+            # Receive response
+            data, _ = sock.recvfrom(1024)
+            logger.debug(f"[UDP Echo] Received: {data.decode()}")
+            assert data.decode() == "Echo", "Unexpected response from UDP Echo server"
+        except socket.timeout:
+            pytest.fail("Timeout: No response from UDP Echo server", pytrace=False)


### PR DESCRIPTION
# Description
<!--
* Prefix: the title with the component name being changed. Add a short and self describing sentence to ease the review
* Please add a few lines providing context and describing the change
* Please self comment changes whenever applicable to help with the review process
* Please keep the checklist as part of the PR. Tick what applies to this change.
-->

Update primarily loadbalancer.go to support UDP
- Removed check preventing creation of UDP LoadBalancer
- Modified updateLoadBalancer to make port/protocol combination is used as key instead of only port
- Check Port/Protocol combination during NLB deletion
- Added healthcheck annotation to make possible to provide a custom healthcheck port
- Added example to readme

Fixes #79

## Checklist
(For exoscale contributors)

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Testing

## Testing

<!--
Describe the tests you did
-->

Added a test variant for NLB creation with UDP
```
❯ gmake test
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/Users/denis/Documents/GitHub/exoscale-cloud-controller-manager/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
go.mk/version.mk:13: warning: overriding recipe for target 'get-version-tag'
/Users/denis/Documents/GitHub/exoscale-cloud-controller-manager/go.mk/version.mk:13: warning: ignoring old recipe for target 'get-version-tag'
'/opt/homebrew/bin/go' test \
  -race \
  -timeout 15s \
   \
  github.com/exoscale/exoscale-cloud-controller-manager/exoscale
ok  	github.com/exoscale/exoscale-cloud-controller-manager/exoscale	5.832s
```

Manual tests done:
- Added and checked UDP services
- Modified service ports
    - Modifying 8080/tcp, 8080/udp to  8081/tcp, 8080/udp works out of the box
    - Modifying back to the same port/different protocol combination needs `kubectl apply --server-side` because of a long lasting kubectl bug:https://github.com/kubernetes/kubernetes/issues/105610
    - Talked successfully to UDP service via netcat, both with externalTrafficPolicy Cluster (and provided healthcheckport in annotation) and with Local (without the sidecar container and annotation)
- Deletion of NLB
- Classical NLB setup with nginx ingress

