### PR TITLE
fix: replace deprecated node-role label in example ccm deployment

### DIFF
--- a/docs/examples/cloud-controller-manager.yml
+++ b/docs/examples/cloud-controller-manager.yml
@@ -25,7 +25,7 @@ spec:
           effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           effect: NoSchedule
       containers:
       - image: exoscale/cloud-controller-manager:latest


### PR DESCRIPTION
# Description

While deploying the CCM using the manifest from docs/examples/ the Pod got stuck in Pending due to the control-plane taint not being tolerated. My Nodes run Kubernetes v1.35.0 where control-plane Nodes are tainted with `node-role.kubernetes.io/control-plane:NoSchedule` instead of the deprecated `node-role.kubernetes.io/master:NoSchedule`.

The current tolerations only handle the old taint causing scheduling to fail on newer Kubernetes clusters.

## Checklist

* [ ] Changelog updated (under *Unreleased* block)
* [ ] Unit tests passed
* [ ] End-to-end tests passed
